### PR TITLE
Set user agent in client to AnyConnect

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -394,6 +394,9 @@ var authenticate = func(d *DBusClient) error {
 
 	parameters := []string{
 		"--protocol=anyconnect",
+		// some VPN servers reject connections from other clients,
+		// set user agent to AnyConnect
+		"--useragent=AnyConnect",
 		certificate,
 		sslKey,
 		xmlConfig,


### PR DESCRIPTION
Some VPN servers reject connections from other clients, so set the user agent to AnyConnect.
See https://gitlab.com/openconnect/openconnect/-/issues/544