### PR TITLE
Change systemd service type to dbus

### DIFF
--- a/init/oc-daemon.service
+++ b/init/oc-daemon.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=OpenConnect Daemon
-After=network.target
+Requires=dbus.service
+After=network.target dbus.service
 
 [Service]
-Type=simple
+Type=dbus
+BusName=com.telekom_mms.oc_daemon.Daemon
 Restart=on-failure
 ExecStart=/usr/bin/oc-daemon
 KillSignal=SIGINT


### PR DESCRIPTION
OC-Daemon relies on D-Bus. So, change the systemd service type to dbus, set the bus name and D-Bus dependencies.