### PR TITLE
Feature/improve oc client output

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -137,6 +137,17 @@ func reconnectVPN() {
 
 // printStatus prints status on the command line
 func printStatus(status *vpnstatus.Status) {
+	if json {
+		// print status as json
+		j, err := status.JSON()
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(string(j))
+		return
+	}
+
+	// print status
 	fmt.Printf("Trusted Network:  %s\n", status.TrustedNetwork)
 	fmt.Printf("Connection State: %s\n", status.ConnectionState)
 	fmt.Printf("IP:               %s\n", status.IP)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -142,10 +142,10 @@ func printStatus(status *vpnstatus.Status) {
 	fmt.Printf("IP:               %s\n", status.IP)
 	fmt.Printf("Device:           %s\n", status.Device)
 
-	connectedAt := time.Unix(status.ConnectedAt, 0)
-	if connectedAt.IsZero() {
-		fmt.Printf("Connected At:     0\n")
+	if status.ConnectedAt <= 0 {
+		fmt.Printf("Connected At:\n")
 	} else {
+		connectedAt := time.Unix(status.ConnectedAt, 0)
 		fmt.Printf("Connected At:     %s\n", connectedAt)
 	}
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -155,7 +155,11 @@ func printStatus(status *vpnstatus.Status) {
 	}
 
 	fmt.Printf("OC Running:       %s\n", status.OCRunning)
-	fmt.Printf("VPN Config:       %+v\n", status.VPNConfig)
+	if status.VPNConfig == nil {
+		fmt.Printf("VPN Config:\n")
+	} else {
+		fmt.Printf("VPN Config:       %+v\n", *status.VPNConfig)
+	}
 }
 
 // getStatus gets the VPN status from the daemon

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -166,6 +166,11 @@ func printStatus(status *vpnstatus.Status) {
 	}
 
 	fmt.Printf("OC Running:       %s\n", status.OCRunning)
+
+	// verbose output
+	if !verbose {
+		return
+	}
 	if status.VPNConfig == nil {
 		fmt.Printf("VPN Config:\n")
 	} else {

--- a/internal/client/cmd.go
+++ b/internal/client/cmd.go
@@ -18,6 +18,9 @@ var (
 	// command line arguments
 	command = ""
 
+	// verbose specifies verbose output
+	verbose = false
+
 	// json specifies whether output should be formatted as json
 	json = false
 )
@@ -38,6 +41,7 @@ func saveConfig() {
 func setConfig() {
 	// status subcommand
 	statusCmd := flag.NewFlagSet("status", flag.ExitOnError)
+	statusCmd.BoolVar(&verbose, "verbose", verbose, "set verbose output")
 	statusCmd.BoolVar(&json, "json", json, "set json output")
 
 	// define command line arguments

--- a/internal/client/cmd.go
+++ b/internal/client/cmd.go
@@ -17,6 +17,9 @@ var (
 
 	// command line arguments
 	command = ""
+
+	// json specifies whether output should be formatted as json
+	json = false
 )
 
 // saveConfig saves the user config to the user dir
@@ -33,6 +36,10 @@ func saveConfig() {
 
 // setConfig sets the config from config files and the command line
 func setConfig() {
+	// status subcommand
+	statusCmd := flag.NewFlagSet("status", flag.ExitOnError)
+	statusCmd.BoolVar(&json, "json", json, "set json output")
+
 	// define command line arguments
 	cfgFile := flag.String("config", "", "set config `file`")
 	cert := flag.String("cert", "", "set client certificate `file` or "+
@@ -95,6 +102,13 @@ func setConfig() {
 	if *ver {
 		fmt.Println(daemon.Version)
 		os.Exit(0)
+	}
+
+	// parse subcommands
+	command = flag.Arg(0)
+	switch command {
+	case "status":
+		_ = statusCmd.Parse(os.Args[2:])
 	}
 
 	// set command


### PR DESCRIPTION
Improve the oc-client status output:
- Do not show connection timestamp as date/time if it is <= 0
- Add JSON output
- Show VPN Config in verbose mode only
- Do not show `<nil>` if no VPN Config is set
- Do not show `&` in front of VPN Config