### PR TITLE
Add current VPN server to OC-Client status

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -152,6 +152,7 @@ func printStatus(status *vpnstatus.Status) {
 	fmt.Printf("Connection State: %s\n", status.ConnectionState)
 	fmt.Printf("IP:               %s\n", status.IP)
 	fmt.Printf("Device:           %s\n", status.Device)
+	fmt.Printf("Current Server:   %s\n", status.Server)
 
 	if status.ConnectedAt <= 0 {
 		fmt.Printf("Connected At:\n")

--- a/internal/dbusapi/service.go
+++ b/internal/dbusapi/service.go
@@ -21,6 +21,7 @@ const (
 	PropertyConnectionState = "ConnectionState"
 	PropertyIP              = "IP"
 	PropertyDevice          = "Device"
+	PropertyServer          = "Server"
 	PropertyConnectedAt     = "ConnectedAt"
 	PropertyServers         = "Servers"
 	PropertyOCRunning       = "OCRunning"
@@ -51,6 +52,11 @@ const (
 // Property "Device" values
 const (
 	DeviceInvalid = ""
+)
+
+// Property "Server" values
+const (
+	ServerInvalid = ""
 )
 
 // Property "Connected At" values
@@ -119,11 +125,11 @@ type daemon struct {
 }
 
 // Connect is the "Connect" method of the D-Bus interface
-func (d daemon) Connect(sender dbus.Sender, cookie, host, connectURL, fingerprint, resolve string) *dbus.Error {
+func (d daemon) Connect(sender dbus.Sender, server, cookie, host, connectURL, fingerprint, resolve string) *dbus.Error {
 	log.WithField("sender", sender).Debug("Received D-Bus Connect() call")
 	request := &Request{
 		Name:       RequestConnect,
-		Parameters: []any{cookie, host, connectURL, fingerprint, resolve},
+		Parameters: []any{server, cookie, host, connectURL, fingerprint, resolve},
 		wait:       make(chan struct{}),
 		done:       d.done,
 	}
@@ -252,6 +258,12 @@ func (s *Service) start() {
 				Emit:     prop.EmitTrue,
 				Callback: nil,
 			},
+			PropertyServer: {
+				Value:    ServerInvalid,
+				Writable: false,
+				Emit:     prop.EmitTrue,
+				Callback: nil,
+			},
 			PropertyConnectedAt: {
 				Value:    ConnectedAtInvalid,
 				Writable: false,
@@ -308,6 +320,7 @@ func (s *Service) start() {
 	props.SetMust(Interface, PropertyConnectionState, ConnectionStateDisconnected)
 	props.SetMust(Interface, PropertyIP, IPInvalid)
 	props.SetMust(Interface, PropertyDevice, DeviceInvalid)
+	props.SetMust(Interface, PropertyServer, ServerInvalid)
 	props.SetMust(Interface, PropertyConnectedAt, ConnectedAtInvalid)
 	props.SetMust(Interface, PropertyServers, ServersInvalid)
 	props.SetMust(Interface, PropertyOCRunning, OCRunningNotRunning)
@@ -332,6 +345,7 @@ func (s *Service) start() {
 			props.SetMust(Interface, PropertyConnectionState, ConnectionStateUnknown)
 			props.SetMust(Interface, PropertyIP, IPInvalid)
 			props.SetMust(Interface, PropertyDevice, DeviceInvalid)
+			props.SetMust(Interface, PropertyServer, ServerInvalid)
 			props.SetMust(Interface, PropertyConnectedAt, ConnectedAtInvalid)
 			props.SetMust(Interface, PropertyServers, ServersInvalid)
 			props.SetMust(Interface, PropertyOCRunning, OCRunningUnknown)

--- a/internal/dbusapi/service_test.go
+++ b/internal/dbusapi/service_test.go
@@ -46,11 +46,11 @@ func TestDaemonConnect(t *testing.T) {
 	}
 
 	// run connect and get results
-	cookie, host, connectURL, fingerprint, resolve :=
-		"cookie", "host", "connectURL", "fingerprint", "resolve"
+	server, cookie, host, connectURL, fingerprint, resolve :=
+		"server", "cookie", "host", "connectURL", "fingerprint", "resolve"
 	want := &Request{
 		Name:       RequestConnect,
-		Parameters: []any{cookie, host, connectURL, fingerprint, resolve},
+		Parameters: []any{server, cookie, host, connectURL, fingerprint, resolve},
 		done:       done,
 	}
 	got := &Request{}
@@ -59,7 +59,7 @@ func TestDaemonConnect(t *testing.T) {
 		got = r
 		r.Close()
 	}()
-	err := daemon.Connect("sender", cookie, host, connectURL, fingerprint, resolve)
+	err := daemon.Connect("sender", server, cookie, host, connectURL, fingerprint, resolve)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -138,6 +138,8 @@ func updateStatusFromProperties(status *vpnstatus.Status, props map[string]dbus.
 				err = v.Store(&dest.IP)
 			case dbusapi.PropertyDevice:
 				err = v.Store(&dest.Device)
+			case dbusapi.PropertyServer:
+				err = v.Store(&dest.Server)
 			case dbusapi.PropertyConnectedAt:
 				err = v.Store(&dest.ConnectedAt)
 			case dbusapi.PropertyServers:
@@ -452,6 +454,7 @@ var authenticate = func(d *DBusClient) error {
 	//
 	s := b.String()
 	login := &logininfo.LoginInfo{}
+	login.Server = config.VPNServer
 	for _, line := range strings.Fields(s) {
 		login.ParseLine(line)
 	}
@@ -477,6 +480,7 @@ var connect = func(d *DBusClient) error {
 	login := d.GetLogin()
 	return d.conn.Object(dbusapi.Interface, dbusapi.Path).
 		Call(dbusapi.MethodConnect, 0,
+			login.Server,
 			login.Cookie,
 			login.Host,
 			login.ConnectURL,

--- a/pkg/logininfo/logininfo.go
+++ b/pkg/logininfo/logininfo.go
@@ -7,6 +7,7 @@ import (
 
 // LoginInfo is login information for OpenConnect
 type LoginInfo struct {
+	Server      string
 	Cookie      string
 	Host        string
 	ConnectURL  string
@@ -26,6 +27,7 @@ func (l *LoginInfo) Copy() *LoginInfo {
 // Valid returns if the login information is valid
 func (l *LoginInfo) Valid() bool {
 	if l == nil ||
+		l.Server == "" ||
 		l.Cookie == "" ||
 		l.Host == "" ||
 		l.Fingerprint == "" {

--- a/pkg/logininfo/logininfo_test.go
+++ b/pkg/logininfo/logininfo_test.go
@@ -14,6 +14,7 @@ func getTestLoginInfo() *LoginInfo {
 	// FINGERPRINT='469bb424ec8835944d30bc77c77e8fc1d8e23a42'
 	// RESOLVE='vpnserver.example.com:10.0.0.1'
 	return &LoginInfo{
+		Server:      "vpnserver.example.com",
 		Cookie:      "3311180634@13561856@1339425499@B315A0E29D16C6FD92EE...",
 		Host:        "10.0.0.1",
 		ConnectURL:  "https://vpnserver.example.com",
@@ -54,6 +55,7 @@ func TestLoginInfoValid(t *testing.T) {
 func TestLoginInfoParseLine(t *testing.T) {
 	want := getTestLoginInfo()
 	got := &LoginInfo{}
+	got.Server = "vpnserver.example.com"
 
 	// parse lines (should match values returned by getTestLoginInfo)
 	for _, line := range []string{

--- a/pkg/vpnstatus/status.go
+++ b/pkg/vpnstatus/status.go
@@ -102,6 +102,7 @@ type Status struct {
 	ConnectionState ConnectionState
 	IP              string
 	Device          string
+	Server          string
 	ConnectedAt     int64
 	Servers         []string
 	OCRunning       OCRunning


### PR DESCRIPTION
Transfer the name of the VPN server we are connecting to from OC-Client to OC-Daemon and show it in oc-client status.