### PR TITLE
Avoid overwriting defaults in config parsing

### DIFF
--- a/internal/ocrunner/config.go
+++ b/internal/ocrunner/config.go
@@ -94,7 +94,7 @@ func NewConfig() *Config {
 		PIDPermissions: PIDPermissions,
 
 		NoProxy:   NoProxy,
-		ExtraEnv:  ExtraEnv,
-		ExtraArgs: ExtraArgs,
+		ExtraEnv:  append(ExtraEnv[:0:0], ExtraEnv...),
+		ExtraArgs: append(ExtraArgs[:0:0], ExtraArgs...),
 	}
 }

--- a/internal/trafpol/config.go
+++ b/internal/trafpol/config.go
@@ -62,7 +62,7 @@ func (c *Config) Valid() bool {
 // NewConfig returns a new TrafPol configuration
 func NewConfig() *Config {
 	return &Config{
-		AllowedHosts: AllowedHosts,
+		AllowedHosts: append(AllowedHosts[:0:0], AllowedHosts...),
 
 		ResolveTimeout:    ResolveTimeout,
 		ResolveTries:      ResolveTries,

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -147,8 +147,8 @@ func NewConfig() *Config {
 		UserAgent:   UserAgent,
 		Quiet:       Quiet,
 		NoProxy:     NoProxy,
-		ExtraEnv:    ExtraEnv,
-		ExtraArgs:   ExtraArgs,
+		ExtraEnv:    append(ExtraEnv[:0:0], ExtraEnv...),
+		ExtraArgs:   append(ExtraArgs[:0:0], ExtraArgs...),
 	}
 }
 


### PR DESCRIPTION
Copy slices containing default values in NewConfig() functions to avoid overwriting the defaults during parsing of JSON config files.