### PR TITLE
Feature/add executables package

### DIFF
--- a/configs/oc-daemon.json
+++ b/configs/oc-daemon.json
@@ -31,6 +31,12 @@
 		"ExtraEnv": [],
 		"ExtraArgs": []
 	},
+	"Executables": {
+		"IP": "ip",
+		"Nft": "nft",
+		"Resolvectl": "resolvectl",
+		"Sysctl": "sysctl"
+	},
 	"SplitRouting": {
 		"RoutingTable": "42111",
 		"RulePriority1": "2111",

--- a/internal/daemon/config.go
+++ b/internal/daemon/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/telekom-mms/oc-daemon/internal/api"
 	"github.com/telekom-mms/oc-daemon/internal/cpd"
 	"github.com/telekom-mms/oc-daemon/internal/dnsproxy"
+	"github.com/telekom-mms/oc-daemon/internal/execs"
 	"github.com/telekom-mms/oc-daemon/internal/ocrunner"
 	"github.com/telekom-mms/oc-daemon/internal/splitrt"
 	"github.com/telekom-mms/oc-daemon/internal/trafpol"
@@ -33,6 +34,7 @@ type Config struct {
 	CPD             *cpd.Config
 	DNSProxy        *dnsproxy.Config
 	OpenConnect     *ocrunner.Config
+	Executables     *execs.Config
 	SplitRouting    *splitrt.Config
 	TrafficPolicing *trafpol.Config
 }
@@ -44,6 +46,7 @@ func (c *Config) Valid() bool {
 		!c.CPD.Valid() ||
 		!c.DNSProxy.Valid() ||
 		!c.OpenConnect.Valid() ||
+		!c.Executables.Valid() ||
 		!c.SplitRouting.Valid() ||
 		!c.TrafficPolicing.Valid() {
 		// invalid
@@ -78,6 +81,7 @@ func NewConfig() *Config {
 		CPD:             cpd.NewConfig(),
 		DNSProxy:        dnsproxy.NewConfig(),
 		OpenConnect:     ocrunner.NewConfig(),
+		Executables:     execs.NewConfig(),
 		SplitRouting:    splitrt.NewConfig(),
 		TrafficPolicing: trafpol.NewConfig(),
 	}

--- a/internal/daemon/config_test.go
+++ b/internal/daemon/config_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/telekom-mms/oc-daemon/internal/api"
 	"github.com/telekom-mms/oc-daemon/internal/cpd"
 	"github.com/telekom-mms/oc-daemon/internal/dnsproxy"
+	"github.com/telekom-mms/oc-daemon/internal/execs"
 	"github.com/telekom-mms/oc-daemon/internal/ocrunner"
 	"github.com/telekom-mms/oc-daemon/internal/splitrt"
 	"github.com/telekom-mms/oc-daemon/internal/trafpol"
@@ -100,6 +101,12 @@ func TestConfigLoad(t *testing.T) {
 		"PIDGroup": "",
 		"PIDPermissions": "0600"
 	},
+	"Executables": {
+		"IP": "ip",
+		"Nft": "nft",
+		"Resolvectl": "resolvectl",
+		"Sysctl": "sysctl"
+	},
 	"SplitRouting": {
 		"RoutingTable": "42111",
 		"RulePriority1": "2111",
@@ -149,6 +156,7 @@ func TestConfigLoad(t *testing.T) {
 			CPD:             cpd.NewConfig(),
 			DNSProxy:        dnsproxy.NewConfig(),
 			OpenConnect:     ocrunner.NewConfig(),
+			Executables:     execs.NewConfig(),
 			SplitRouting:    splitrt.NewConfig(),
 			TrafficPolicing: trafpol.NewConfig(),
 		}
@@ -157,6 +165,9 @@ func TestConfigLoad(t *testing.T) {
 		}
 		if !reflect.DeepEqual(want.OpenConnect, config.OpenConnect) {
 			t.Errorf("got %v, want %v", config.OpenConnect, want.OpenConnect)
+		}
+		if !reflect.DeepEqual(want.Executables, config.Executables) {
+			t.Errorf("got %v, want %v", config.Executables, want.Executables)
 		}
 		if !reflect.DeepEqual(want.SplitRouting, config.SplitRouting) {
 			t.Errorf("got %v, want %v", config.SplitRouting, want.SplitRouting)
@@ -179,6 +190,7 @@ func TestNewConfig(t *testing.T) {
 		CPD:             cpd.NewConfig(),
 		DNSProxy:        dnsproxy.NewConfig(),
 		OpenConnect:     ocrunner.NewConfig(),
+		Executables:     execs.NewConfig(),
 		SplitRouting:    splitrt.NewConfig(),
 		TrafficPolicing: trafpol.NewConfig(),
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/telekom-mms/oc-daemon/internal/api"
 	"github.com/telekom-mms/oc-daemon/internal/dbusapi"
+	"github.com/telekom-mms/oc-daemon/internal/execs"
 	"github.com/telekom-mms/oc-daemon/internal/ocrunner"
 	"github.com/telekom-mms/oc-daemon/internal/profilemon"
 	"github.com/telekom-mms/oc-daemon/internal/sleepmon"
@@ -639,6 +640,9 @@ func (d *Daemon) checkTrafPol() {
 // start starts the daemon
 func (d *Daemon) start() {
 	defer close(d.closed)
+
+	// set executables
+	execs.SetExecutables(d.config.Executables)
 
 	// cleanup after a failed shutdown
 	d.cleanup()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"net"
@@ -477,10 +478,10 @@ func (d *Daemon) handleProfileUpdate() {
 }
 
 // cleanup cleans up after a failed shutdown
-func (d *Daemon) cleanup() {
+func (d *Daemon) cleanup(ctx context.Context) {
 	ocrunner.CleanupConnect(d.config.OpenConnect)
 	vpnsetup.Cleanup(d.config.OpenConnect.VPNDevice, d.config.SplitRouting)
-	trafpol.Cleanup()
+	trafpol.Cleanup(ctx)
 }
 
 // initToken creates the daemon token for client authentication
@@ -641,11 +642,14 @@ func (d *Daemon) checkTrafPol() {
 func (d *Daemon) start() {
 	defer close(d.closed)
 
+	// create context
+	ctx := context.Background()
+
 	// set executables
 	execs.SetExecutables(d.config.Executables)
 
 	// cleanup after a failed shutdown
-	d.cleanup()
+	d.cleanup(ctx)
 
 	// init token
 	d.initToken()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -480,7 +480,7 @@ func (d *Daemon) handleProfileUpdate() {
 // cleanup cleans up after a failed shutdown
 func (d *Daemon) cleanup(ctx context.Context) {
 	ocrunner.CleanupConnect(d.config.OpenConnect)
-	vpnsetup.Cleanup(d.config.OpenConnect.VPNDevice, d.config.SplitRouting)
+	vpnsetup.Cleanup(ctx, d.config.OpenConnect.VPNDevice, d.config.SplitRouting)
 	trafpol.Cleanup(ctx)
 }
 

--- a/internal/execs/config.go
+++ b/internal/execs/config.go
@@ -1,0 +1,39 @@
+package execs
+
+// default values
+var (
+	IP         = "ip"
+	Nft        = "nft"
+	Resolvectl = "resolvectl"
+	Sysctl     = "sysctl"
+)
+
+// Config is executables configuration
+type Config struct {
+	IP         string
+	Nft        string
+	Resolvectl string
+	Sysctl     string
+}
+
+// Valid returns whether config is valid
+func (c *Config) Valid() bool {
+	if c == nil ||
+		c.IP == "" ||
+		c.Nft == "" ||
+		c.Resolvectl == "" {
+		// invalid
+		return false
+	}
+	return true
+}
+
+// NewConfig returns a new Config
+func NewConfig() *Config {
+	return &Config{
+		IP:         IP,
+		Nft:        Nft,
+		Resolvectl: Resolvectl,
+		Sysctl:     Sysctl,
+	}
+}

--- a/internal/execs/config_test.go
+++ b/internal/execs/config_test.go
@@ -1,0 +1,38 @@
+package execs
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestConfigValid tests Valid of Config
+func TestConfigValid(t *testing.T) {
+	// test invalid
+	for _, invalid := range []*Config{
+		nil,
+		{},
+	} {
+		if invalid.Valid() {
+			t.Errorf("config should be invalid: %v", invalid)
+		}
+	}
+
+	// test valid
+	for _, valid := range []*Config{
+		NewConfig(),
+		{"/test/ip", "/test/nft", "/test/resolvectl", "/test/sysctl"},
+	} {
+		if !valid.Valid() {
+			t.Errorf("config should be valid: %v", valid)
+		}
+	}
+}
+
+// TestNewConfig tests NewConfig
+func TestNewConfig(t *testing.T) {
+	want := &Config{IP, Nft, Resolvectl, Sysctl}
+	got := NewConfig()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/internal/execs/execs.go
+++ b/internal/execs/execs.go
@@ -1,0 +1,88 @@
+package execs
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+)
+
+// executables
+var (
+	ip         = IP
+	sysctl     = Sysctl
+	nft        = Nft
+	resolvectl = Resolvectl
+)
+
+// RunCmd runs the cmd with args and sets stdin to s
+var RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+	c := exec.CommandContext(ctx, cmd, arg...)
+	if s != "" {
+		c.Stdin = bytes.NewBufferString(s)
+	}
+	return c.Run()
+}
+
+// RunIP runs the "ip" command with args
+func RunIP(ctx context.Context, arg ...string) error {
+	return RunCmd(ctx, ip, "", arg...)
+}
+
+// RunIPLink runs the "ip link" command with args
+func RunIPLink(ctx context.Context, arg ...string) error {
+	a := append([]string{"link"}, arg...)
+	return RunIP(ctx, a...)
+}
+
+// RunIPAddress runs the "ip address" command with args
+func RunIPAddress(ctx context.Context, arg ...string) error {
+	a := append([]string{"address"}, arg...)
+	return RunIP(ctx, a...)
+}
+
+// RunIP4Route runs the "ip -4 route" command with args
+func RunIP4Route(ctx context.Context, arg ...string) error {
+	a := append([]string{"-4", "route"}, arg...)
+	return RunIP(ctx, a...)
+}
+
+// RunIP6Route runs the "ip -6 route" command with args
+func RunIP6Route(ctx context.Context, arg ...string) error {
+	a := append([]string{"-6", "route"}, arg...)
+	return RunIP(ctx, a...)
+}
+
+// RunIP4Rule runs the "ip -4 rule" command with args
+func RunIP4Rule(ctx context.Context, arg ...string) error {
+	a := append([]string{"-4", "rule"}, arg...)
+	return RunIP(ctx, a...)
+}
+
+// RunIP6Rule runs the "ip -6 rule" command with args
+func RunIP6Rule(ctx context.Context, arg ...string) error {
+	a := append([]string{"-6", "rule"}, arg...)
+	return RunIP(ctx, a...)
+}
+
+// RunSysctl runs the "sysctl" command with args
+func RunSysctl(ctx context.Context, arg ...string) error {
+	return RunCmd(ctx, sysctl, "", arg...)
+}
+
+// RunNft runs the "nft -f -" command and sets stdin to s
+func RunNft(ctx context.Context, s string) error {
+	return RunCmd(ctx, nft, s, "-f", "-")
+}
+
+// RunResolvectl runs the "resolvectl" command with args
+func RunResolvectl(ctx context.Context, arg ...string) error {
+	return RunCmd(ctx, resolvectl, "", arg...)
+}
+
+// SetExecutables configures all executables from config
+func SetExecutables(config *Config) {
+	ip = config.IP
+	sysctl = config.Sysctl
+	nft = config.Nft
+	resolvectl = config.Resolvectl
+}

--- a/internal/execs/execs_test.go
+++ b/internal/execs/execs_test.go
@@ -1,0 +1,189 @@
+package execs
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestRunCmd tests RunCmd
+func TestRunCmd(t *testing.T) {
+	ctx := context.Background()
+
+	// test not existing
+	dir, err := os.MkdirTemp("", "runcmd-test")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	if err := RunCmd(ctx, filepath.Join(dir, "does/not/exist"), ""); err == nil {
+		t.Errorf("running not existing command should fail: %v", err)
+	}
+
+	// test existing
+	if err := RunCmd(ctx, "echo", "", "this", "is", "a", "test"); err != nil {
+		t.Errorf("running echo failed: %v", err)
+	}
+}
+
+// TestRunIP tests RunIP
+func TestRunIP(t *testing.T) {
+	want := []string{"ip address show"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " "))
+		return nil
+	}
+	_ = RunIP(context.Background(), "address", "show")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestRunIPLink tests RunIPLink
+func TestRunIPLink(t *testing.T) {
+	want := []string{"ip link show"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " "))
+		return nil
+	}
+	_ = RunIPLink(context.Background(), "show")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestRunIPAddress tests RunIPAddress
+func TestRunIPAddress(t *testing.T) {
+	want := []string{"ip address show"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " "))
+		return nil
+	}
+	_ = RunIPAddress(context.Background(), "show")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestRunIP4Route tests RunIP4Route
+func TestRunIP4Route(t *testing.T) {
+	want := []string{"ip -4 route show"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " "))
+		return nil
+	}
+	_ = RunIP4Route(context.Background(), "show")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestRunIP6Route tests RunIP6Route
+func TestRunIP6Route(t *testing.T) {
+	want := []string{"ip -6 route show"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " "))
+		return nil
+	}
+	_ = RunIP6Route(context.Background(), "show")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestRunIP4Rule tests RunIP4Rule
+func TestRunIP4Rule(t *testing.T) {
+	want := []string{"ip -4 rule show"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " "))
+		return nil
+	}
+	_ = RunIP4Rule(context.Background(), "show")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestRunIP6Rule tests RunIP6Rule
+func TestRunIP6Rule(t *testing.T) {
+	want := []string{"ip -6 rule show"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " "))
+		return nil
+	}
+	_ = RunIP6Rule(context.Background(), "show")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestRunSysctl tests RunSysctl
+func TestRunSysctl(t *testing.T) {
+	want := []string{"sysctl -q net.ipv4.conf.all.src_valid_mark=1"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " "))
+		return nil
+	}
+	_ = RunSysctl(context.Background(), "-q", "net.ipv4.conf.all.src_valid_mark=1")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestRunNft tests RunNft
+func TestRunNft(t *testing.T) {
+	want := []string{"nft -f - list tables"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " ")+" "+s)
+		return nil
+	}
+	_ = RunNft(context.Background(), "list tables")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestRunResolvectl tests RunResolvectl
+func TestRunResolvectl(t *testing.T) {
+	want := []string{"resolvectl dns"}
+	got := []string{}
+	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
+		got = append(got, cmd+" "+strings.Join(arg, " "))
+		return nil
+	}
+	_ = RunResolvectl(context.Background(), "dns")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestSetExecutables tests SetExecutables
+func TestSetExecutables(t *testing.T) {
+	config := &Config{
+		IP:         "/test/ip",
+		Sysctl:     "/test/sysctl",
+		Nft:        "/test/nft",
+		Resolvectl: "/test/resolvectl",
+	}
+	SetExecutables(config)
+	if ip != config.IP ||
+		sysctl != config.Sysctl ||
+		nft != config.Nft ||
+		resolvectl != config.Resolvectl {
+		// executables not set properly
+		t.Errorf("executables incorrect")
+	}
+}

--- a/internal/splitrt/excludes_test.go
+++ b/internal/splitrt/excludes_test.go
@@ -28,6 +28,7 @@ func getTestExcludes() []*net.IPNet {
 
 // TestExcludesAddStatic tests AddStatic of Excludes
 func TestExcludesAddStatic(t *testing.T) {
+	ctx := context.Background()
 	e := NewExcludes()
 	excludes := getTestExcludes()
 
@@ -44,7 +45,7 @@ func TestExcludesAddStatic(t *testing.T) {
 		"add element inet oc-daemon-routing excludes6 { 2001::/64 }",
 	}
 	for _, exclude := range excludes {
-		e.AddStatic(exclude)
+		e.AddStatic(ctx, exclude)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -52,7 +53,7 @@ func TestExcludesAddStatic(t *testing.T) {
 
 	// test adding excludes again, should not change nft commands
 	for _, exclude := range excludes {
-		e.AddStatic(exclude)
+		e.AddStatic(ctx, exclude)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -61,6 +62,7 @@ func TestExcludesAddStatic(t *testing.T) {
 
 // TestExcludesAddDynamic tests AddDynamic of Excludes
 func TestExcludesAddDynamic(t *testing.T) {
+	ctx := context.Background()
 	e := NewExcludes()
 	excludes := getTestExcludes()
 
@@ -77,7 +79,7 @@ func TestExcludesAddDynamic(t *testing.T) {
 		"add element inet oc-daemon-routing excludes6 { 2001::/64 }",
 	}
 	for _, exclude := range excludes {
-		e.AddDynamic(exclude, 300)
+		e.AddDynamic(ctx, exclude, 300)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -85,7 +87,7 @@ func TestExcludesAddDynamic(t *testing.T) {
 
 	// test adding excludes again, should not change nft commands
 	for _, exclude := range excludes {
-		e.AddDynamic(exclude, 300)
+		e.AddDynamic(ctx, exclude, 300)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -94,6 +96,7 @@ func TestExcludesAddDynamic(t *testing.T) {
 
 // TestExcludesRemove tests Remove of Excludes
 func TestExcludesRemove(t *testing.T) {
+	ctx := context.Background()
 	e := NewExcludes()
 	excludes := getTestExcludes()
 
@@ -112,7 +115,7 @@ func TestExcludesRemove(t *testing.T) {
 			"flush set inet oc-daemon-routing excludes6\n",
 	}
 	for _, exclude := range excludes {
-		e.Remove(exclude)
+		e.Remove(ctx, exclude)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -130,10 +133,10 @@ func TestExcludesRemove(t *testing.T) {
 			"flush set inet oc-daemon-routing excludes6\n",
 	}
 	for _, exclude := range excludes {
-		e.AddStatic(exclude)
+		e.AddStatic(ctx, exclude)
 	}
 	for _, exclude := range excludes {
-		e.Remove(exclude)
+		e.Remove(ctx, exclude)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -143,10 +146,10 @@ func TestExcludesRemove(t *testing.T) {
 	// should have same nft commands as static case
 	got = []string{}
 	for _, exclude := range excludes {
-		e.AddDynamic(exclude, 300)
+		e.AddDynamic(ctx, exclude, 300)
 	}
 	for _, exclude := range excludes {
-		e.Remove(exclude)
+		e.Remove(ctx, exclude)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -155,6 +158,7 @@ func TestExcludesRemove(t *testing.T) {
 
 // TestExcludesCleanup tests cleanup of Excludes
 func TestExcludesCleanup(t *testing.T) {
+	ctx := context.Background()
 	e := NewExcludes()
 	excludes := getTestExcludes()
 
@@ -167,20 +171,20 @@ func TestExcludesCleanup(t *testing.T) {
 
 	// test without excludes
 	want := []string{}
-	e.cleanup()
+	e.cleanup(ctx)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
 	// test with dynamic excludes
 	for _, exclude := range excludes {
-		e.AddDynamic(exclude, excludesTimer)
+		e.AddDynamic(ctx, exclude, excludesTimer)
 	}
 
 	got = []string{}
 	for i := 0; i <= excludesTimer; i += excludesTimer {
 		want := []string{}
-		e.cleanup()
+		e.cleanup(ctx)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v, want %v", got, want)
 		}
@@ -189,18 +193,18 @@ func TestExcludesCleanup(t *testing.T) {
 		"flush set inet oc-daemon-routing excludes4\n" +
 			"flush set inet oc-daemon-routing excludes6\n",
 	}
-	e.cleanup()
+	e.cleanup(ctx)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
 	// test with static excludes
 	for _, exclude := range excludes {
-		e.AddStatic(exclude)
+		e.AddStatic(ctx, exclude)
 	}
 	got = []string{}
 	want = []string{}
-	e.cleanup()
+	e.cleanup(ctx)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}

--- a/internal/splitrt/excludes_test.go
+++ b/internal/splitrt/excludes_test.go
@@ -1,10 +1,13 @@
 package splitrt
 
 import (
+	"context"
 	"log"
 	"net"
 	"reflect"
 	"testing"
+
+	"github.com/telekom-mms/oc-daemon/internal/execs"
 )
 
 // getTestExcludes returns excludes for testing
@@ -30,8 +33,9 @@ func TestExcludesAddStatic(t *testing.T) {
 
 	// set testing runNft function
 	got := []string{}
-	runNft = func(s string) {
+	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
 		got = append(got, s)
+		return nil
 	}
 
 	// test adding excludes
@@ -62,8 +66,9 @@ func TestExcludesAddDynamic(t *testing.T) {
 
 	// set testing runNft function
 	got := []string{}
-	runNft = func(s string) {
+	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
 		got = append(got, s)
+		return nil
 	}
 
 	// test adding excludes
@@ -94,8 +99,9 @@ func TestExcludesRemove(t *testing.T) {
 
 	// set testing runNft function
 	got := []string{}
-	runNft = func(s string) {
+	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
 		got = append(got, s)
+		return nil
 	}
 
 	// test removing not existing excludes
@@ -154,8 +160,9 @@ func TestExcludesCleanup(t *testing.T) {
 
 	// set testing runNft function
 	got := []string{}
-	runNft = func(s string) {
+	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
 		got = append(got, s)
+		return nil
 	}
 
 	// test without excludes

--- a/internal/splitrt/filter.go
+++ b/internal/splitrt/filter.go
@@ -11,7 +11,7 @@ import (
 )
 
 // setRoutingRules sets the basic nftables rules for routing
-func setRoutingRules(fwMark string) {
+func setRoutingRules(ctx context.Context, fwMark string) {
 	const routeRules = `
 table inet oc-daemon-routing {
 	# set for ipv4 excludes
@@ -103,15 +103,14 @@ table inet oc-daemon-routing {
 `
 	r := strings.NewReplacer("$FWMARK", fwMark)
 	rules := r.Replace(routeRules)
-	if err := execs.RunNft(context.TODO(), rules); err != nil {
+	if err := execs.RunNft(ctx, rules); err != nil {
 		log.WithError(err).Error("SplitRouting error setting routing rules")
 	}
 }
 
 // unsetRoutingRules removes the nftables rules for routing
-func unsetRoutingRules() {
-	if err := execs.RunNft(context.TODO(),
-		"delete table inet oc-daemon-routing"); err != nil {
+func unsetRoutingRules(ctx context.Context) {
+	if err := execs.RunNft(ctx, "delete table inet oc-daemon-routing"); err != nil {
 		log.WithError(err).Error("SplitRouting error unsetting routing rules")
 	}
 }
@@ -119,7 +118,7 @@ func unsetRoutingRules() {
 // addLocalAddresses adds rules for device and its family (ip, ip6) addresses,
 // that drop non-local traffic from other devices to device's network
 // addresses; used to filter non-local traffic to vpn addresses
-func addLocalAddresses(device, family string, addresses []*net.IPNet) {
+func addLocalAddresses(ctx context.Context, device, family string, addresses []*net.IPNet) {
 	nftconf := ""
 	for _, addr := range addresses {
 		if addr == nil || len(addr.IP) == 0 || len(addr.Mask) == 0 {
@@ -130,7 +129,7 @@ func addLocalAddresses(device, family string, addresses []*net.IPNet) {
 		nftconf += "fib saddr type != local counter drop\n"
 	}
 
-	if err := execs.RunNft(context.TODO(), nftconf); err != nil {
+	if err := execs.RunNft(ctx, nftconf); err != nil {
 		log.WithError(err).Error("SplitRouting error adding local addresses")
 	}
 }
@@ -138,20 +137,20 @@ func addLocalAddresses(device, family string, addresses []*net.IPNet) {
 // addLocalAddressesIPv4 adds rules for device and its addresses, that drop
 // non-local traffic from other devices to device's network addresses; used to
 // filter non-local traffic to vpn addresses
-func addLocalAddressesIPv4(device string, addresses []*net.IPNet) {
-	addLocalAddresses(device, "ip", addresses)
+func addLocalAddressesIPv4(ctx context.Context, device string, addresses []*net.IPNet) {
+	addLocalAddresses(ctx, device, "ip", addresses)
 }
 
 // addLocalAddressesIPv6 adds rules for device and its addresses, that drop
 // non-local traffic from other devices to device's network addresses; used to
 // filter non-local traffic to vpn addresses
-func addLocalAddressesIPv6(device string, addresses []*net.IPNet) {
-	addLocalAddresses(device, "ip6", addresses)
+func addLocalAddressesIPv6(ctx context.Context, device string, addresses []*net.IPNet) {
+	addLocalAddresses(ctx, device, "ip6", addresses)
 }
 
 // rejectIPVersion adds rules for the tunnel device to reject an unsupported ip
 // version ("ipv6" or "ipv4")
-func rejectIPVersion(device, version string) {
+func rejectIPVersion(ctx context.Context, device, version string) {
 	nftconf := ""
 	for _, chain := range []string{"rejectforward", "rejectoutput"} {
 		nftconf += fmt.Sprintf("add rule inet oc-daemon-routing %s ",
@@ -161,25 +160,25 @@ func rejectIPVersion(device, version string) {
 		nftconf += "counter jump rejectipversion\n"
 	}
 
-	if err := execs.RunNft(context.TODO(), nftconf); err != nil {
+	if err := execs.RunNft(ctx, nftconf); err != nil {
 		log.WithError(err).Error("SplitRouting error setting ip version reject rules")
 	}
 }
 
 // rejectIPv6 adds rules for the tunnel device that reject IPv6 traffic on it;
 // used to avoid sending IPv6 packets over a tunnel that only supports IPv4
-func rejectIPv6(device string) {
-	rejectIPVersion(device, "ipv6")
+func rejectIPv6(ctx context.Context, device string) {
+	rejectIPVersion(ctx, device, "ipv6")
 }
 
 // rejectIPv4 adds rules for the tunnel device that reject IPv4 traffic on it;
 // used to avoid sending IPv4 packets over a tunnel that only supports IPv6
-func rejectIPv4(device string) {
-	rejectIPVersion(device, "ipv4")
+func rejectIPv4(ctx context.Context, device string) {
+	rejectIPVersion(ctx, device, "ipv4")
 }
 
 // addExclude adds exclude address to netfilter
-func addExclude(address *net.IPNet) {
+func addExclude(ctx context.Context, address *net.IPNet) {
 	set := "excludes4"
 	if address.IP.To4() == nil {
 		set = "excludes6"
@@ -187,13 +186,13 @@ func addExclude(address *net.IPNet) {
 
 	nftconf := fmt.Sprintf("add element inet oc-daemon-routing %s { %s }",
 		set, address)
-	if err := execs.RunNft(context.TODO(), nftconf); err != nil {
+	if err := execs.RunNft(ctx, nftconf); err != nil {
 		log.WithError(err).Error("SplitRouting error adding exclude")
 	}
 }
 
 // setExcludes resets the excludes to addresses in netfilter
-func setExcludes(addresses []*net.IPNet) {
+func setExcludes(ctx context.Context, addresses []*net.IPNet) {
 	// flush existing entries
 	nftconf := ""
 	nftconf += "flush set inet oc-daemon-routing excludes4\n"
@@ -211,16 +210,15 @@ func setExcludes(addresses []*net.IPNet) {
 	}
 
 	// run command
-	if err := execs.RunNft(context.TODO(), nftconf); err != nil {
+	if err := execs.RunNft(ctx, nftconf); err != nil {
 		log.WithError(err).Error("SplitRouting error setting excludes")
 	}
 }
 
 // cleanupRoutingRules cleans up the nftables rules for routing after a
 // failed shutdown
-func cleanupRoutingRules() {
-	if err := execs.RunNft(context.TODO(),
-		"delete table inet oc-daemon-routing"); err == nil {
+func cleanupRoutingRules(ctx context.Context) {
+	if err := execs.RunNft(ctx, "delete table inet oc-daemon-routing"); err == nil {
 		log.Debug("SplitRouting cleaned up nft")
 	}
 }

--- a/internal/splitrt/route.go
+++ b/internal/splitrt/route.go
@@ -8,9 +8,7 @@ import (
 )
 
 // addDefaultRouteIPv4 adds default routing for IPv4
-func addDefaultRouteIPv4(device, rtTable, rulePrio1, fwMark, rulePrio2 string) {
-	ctx := context.TODO()
-
+func addDefaultRouteIPv4(ctx context.Context, device, rtTable, rulePrio1, fwMark, rulePrio2 string) {
 	// set default route
 	if err := execs.RunIP4Route(ctx, "add", "0.0.0.0/0", "dev", device,
 		"table", rtTable); err != nil {
@@ -35,9 +33,7 @@ func addDefaultRouteIPv4(device, rtTable, rulePrio1, fwMark, rulePrio2 string) {
 }
 
 // addDefaultRouteIPv6 adds default routing for IPv6
-func addDefaultRouteIPv6(device, rtTable, rulePrio1, fwMark, rulePrio2 string) {
-	ctx := context.TODO()
-
+func addDefaultRouteIPv6(ctx context.Context, device, rtTable, rulePrio1, fwMark, rulePrio2 string) {
 	// set default route
 	if err := execs.RunIP6Route(ctx, "add", "::/0", "dev", device, "table",
 		rtTable); err != nil {
@@ -56,9 +52,7 @@ func addDefaultRouteIPv6(device, rtTable, rulePrio1, fwMark, rulePrio2 string) {
 }
 
 // deleteDefaultRouteIPv4 removes default routing for IPv4
-func deleteDefaultRouteIPv4(device, rtTable string) {
-	ctx := context.TODO()
-
+func deleteDefaultRouteIPv4(ctx context.Context, device, rtTable string) {
 	// delete routing rules
 	if err := execs.RunIP4Rule(ctx, "delete", "table", rtTable); err != nil {
 		log.WithError(err).Error("SplitRouting error deleting ipv4 routing rule 2")
@@ -70,9 +64,7 @@ func deleteDefaultRouteIPv4(device, rtTable string) {
 }
 
 // deleteDefaultRouteIPv6 removes default routing for IPv6
-func deleteDefaultRouteIPv6(device, rtTable string) {
-	ctx := context.TODO()
-
+func deleteDefaultRouteIPv6(ctx context.Context, device, rtTable string) {
 	// delete routing rules
 	if err := execs.RunIP6Rule(ctx, "delete", "table", rtTable); err != nil {
 		log.WithError(err).Error("SplitRouting error deleting ipv6 routing rule 2")
@@ -84,9 +76,7 @@ func deleteDefaultRouteIPv6(device, rtTable string) {
 }
 
 // cleanupRouting cleans up the routing configuration after a failed shutdown
-func cleanupRouting(rtTable, rulePrio1, rulePrio2 string) {
-	ctx := context.TODO()
-
+func cleanupRouting(ctx context.Context, rtTable, rulePrio1, rulePrio2 string) {
 	// delete ipv4 routing rules
 	if err := execs.RunIP4Rule(ctx, "delete", "pref", rulePrio1); err == nil {
 		log.Debug("SplitRouting cleaned up ipv4 routing rule 1")

--- a/internal/splitrt/splitrt_test.go
+++ b/internal/splitrt/splitrt_test.go
@@ -17,6 +17,7 @@ import (
 
 // TestSplitRoutingHandleDeviceUpdate tests handleDeviceUpdate of SplitRouting
 func TestSplitRoutingHandleDeviceUpdate(t *testing.T) {
+	ctx := context.Background()
 	s := NewSplitRouting(NewConfig(), vpnconfig.New())
 
 	want := []string{"nothing else"}
@@ -28,14 +29,14 @@ func TestSplitRoutingHandleDeviceUpdate(t *testing.T) {
 
 	// test adding
 	update := getTestDevMonUpdate()
-	s.handleDeviceUpdate(update)
+	s.handleDeviceUpdate(ctx, update)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
 	// test removing
 	update.Add = false
-	s.handleDeviceUpdate(update)
+	s.handleDeviceUpdate(ctx, update)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
@@ -43,6 +44,7 @@ func TestSplitRoutingHandleDeviceUpdate(t *testing.T) {
 
 // TestSplitRoutingHandleAddressUpdate tests handleAddressUpdate of SplitRouting
 func TestSplitRoutingHandleAddressUpdate(t *testing.T) {
+	ctx := context.Background()
 	vpnconf := vpnconfig.New()
 	vpnconf.Split.ExcludeIPv4 = []*net.IPNet{
 		{
@@ -64,7 +66,7 @@ func TestSplitRoutingHandleAddressUpdate(t *testing.T) {
 		"add element inet oc-daemon-routing excludes4 { 192.168.1.1/32 }",
 	}
 	update := getTestAddrMonUpdate("192.168.1.1/32")
-	s.handleAddressUpdate(update)
+	s.handleAddressUpdate(ctx, update)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
@@ -76,7 +78,7 @@ func TestSplitRoutingHandleAddressUpdate(t *testing.T) {
 			"flush set inet oc-daemon-routing excludes6\n",
 	}
 	update.Add = false
-	s.handleAddressUpdate(update)
+	s.handleAddressUpdate(ctx, update)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
@@ -84,6 +86,7 @@ func TestSplitRoutingHandleAddressUpdate(t *testing.T) {
 
 // TestSplitRoutingHandleDNSReport tests handleDNSReport of SplitRouting
 func TestSplitRoutingHandleDNSReport(t *testing.T) {
+	ctx := context.Background()
 	s := NewSplitRouting(NewConfig(), vpnconfig.New())
 
 	got := []string{}
@@ -94,12 +97,12 @@ func TestSplitRoutingHandleDNSReport(t *testing.T) {
 
 	// test ipv4
 	report := dnsproxy.NewReport("example.com", net.ParseIP("192.168.1.1"), 300)
-	go s.handleDNSReport(report)
+	go s.handleDNSReport(ctx, report)
 	report.Wait()
 
 	// test ipv6
 	report = dnsproxy.NewReport("example.com", net.ParseIP("2001::1"), 300)
-	go s.handleDNSReport(report)
+	go s.handleDNSReport(ctx, report)
 	report.Wait()
 
 	want := []string{
@@ -175,7 +178,7 @@ func TestCleanup(t *testing.T) {
 		got = append(got, cmd+" "+strings.Join(arg, " ")+" "+s)
 		return nil
 	}
-	Cleanup(NewConfig())
+	Cleanup(context.Background(), NewConfig())
 	want := []string{
 		"ip -4 rule delete pref 2111",
 		"ip -4 rule delete pref 2112",

--- a/internal/trafpol/allowdevs_test.go
+++ b/internal/trafpol/allowdevs_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"reflect"
 	"testing"
+
+	"github.com/telekom-mms/oc-daemon/internal/execs"
 )
 
 // TestAllowDevsAdd tests Add of AllowDevs
@@ -12,8 +14,9 @@ func TestAllowDevsAdd(t *testing.T) {
 	ctx := context.Background()
 
 	got := []string{}
-	runNft = func(ctx context.Context, s string) {
+	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
 		got = append(got, s)
+		return nil
 	}
 
 	// test adding
@@ -39,8 +42,9 @@ func TestAllowDevsRemove(t *testing.T) {
 	ctx := context.Background()
 
 	got := []string{}
-	runNft = func(ctx context.Context, s string) {
+	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
 		got = append(got, s)
+		return nil
 	}
 
 	// test removing device

--- a/internal/trafpol/filter.go
+++ b/internal/trafpol/filter.go
@@ -244,9 +244,8 @@ func removePortalPorts(ctx context.Context, ports []uint16) {
 }
 
 // cleanupFilterRules cleans up the filter rules after a failed shutdown
-func cleanupFilterRules() {
-	if err := execs.RunNft(context.TODO(),
-		"delete table inet oc-daemon-filter"); err == nil {
+func cleanupFilterRules(ctx context.Context) {
+	if err := execs.RunNft(ctx, "delete table inet oc-daemon-filter"); err == nil {
 		log.Debug("TrafPol cleaned up nft")
 	}
 }

--- a/internal/trafpol/trafpol.go
+++ b/internal/trafpol/trafpol.go
@@ -167,6 +167,6 @@ func NewTrafPol(config *Config) *TrafPol {
 }
 
 // Cleanup cleans up old configuration after a failed shutdown
-func Cleanup() {
-	cleanupFilterRules()
+func Cleanup(ctx context.Context) {
+	cleanupFilterRules(ctx)
 }

--- a/internal/trafpol/trafpol_test.go
+++ b/internal/trafpol/trafpol_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/telekom-mms/oc-daemon/internal/cpd"
 	"github.com/telekom-mms/oc-daemon/internal/devmon"
+	"github.com/telekom-mms/oc-daemon/internal/execs"
 	"github.com/vishvananda/netlink"
 )
 
@@ -49,10 +50,11 @@ func TestTrafPolHandleCPDReport(t *testing.T) {
 
 	var nftMutex sync.Mutex
 	nftCmds := []string{}
-	runNft = func(ctx context.Context, s string) {
+	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
 		nftMutex.Lock()
 		defer nftMutex.Unlock()
 		nftCmds = append(nftCmds, s)
+		return nil
 	}
 	getNftCmds := func() []string {
 		nftMutex.Lock()
@@ -130,8 +132,9 @@ func TestCleanup(t *testing.T) {
 		"delete table inet oc-daemon-filter",
 	}
 	got := []string{}
-	runCleanupNft = func(s string) {
+	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) error {
 		got = append(got, s)
+		return nil
 	}
 	Cleanup()
 	if !reflect.DeepEqual(got, want) {

--- a/internal/trafpol/trafpol_test.go
+++ b/internal/trafpol/trafpol_test.go
@@ -136,7 +136,7 @@ func TestCleanup(t *testing.T) {
 		got = append(got, s)
 		return nil
 	}
-	Cleanup()
+	Cleanup(context.Background())
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}

--- a/internal/vpnsetup/vpnsetup.go
+++ b/internal/vpnsetup/vpnsetup.go
@@ -337,5 +337,5 @@ func Cleanup(ctx context.Context, vpnDevice string, splitrtConfig *splitrt.Confi
 		log.WithField("device", vpnDevice).
 			Warn("VPNSetup cleaned up vpn device")
 	}
-	splitrt.Cleanup(splitrtConfig)
+	splitrt.Cleanup(ctx, splitrtConfig)
 }

--- a/internal/vpnsetup/vpnsetup_test.go
+++ b/internal/vpnsetup/vpnsetup_test.go
@@ -37,7 +37,7 @@ func TestSetupVPNDevice(t *testing.T) {
 	}
 
 	// test
-	setupVPNDevice(c)
+	setupVPNDevice(context.Background(), c)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
@@ -59,7 +59,7 @@ func TestTeardownVPNDevice(t *testing.T) {
 	}
 
 	// test
-	teardownVPNDevice(c)
+	teardownVPNDevice(context.Background(), c)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
@@ -77,7 +77,7 @@ func TestVPNSetupSetupDNS(t *testing.T) {
 		return nil
 	}
 	v := NewVPNSetup(dnsproxy.NewConfig(), splitrt.NewConfig())
-	v.setupDNS(c)
+	v.setupDNS(context.Background(), c)
 
 	want := []string{
 		"dns tun0 127.0.0.1:4253",
@@ -102,7 +102,7 @@ func TestVPNSetupTeardownDNS(t *testing.T) {
 		return nil
 	}
 	v := NewVPNSetup(dnsproxy.NewConfig(), splitrt.NewConfig())
-	v.teardownDNS(c)
+	v.teardownDNS(context.Background(), c)
 
 	want := []string{
 		"revert tun0",
@@ -158,7 +158,7 @@ func TestCleanup(t *testing.T) {
 		got = append(got, cmd+" "+strings.Join(arg, " ")+" "+s)
 		return nil
 	}
-	Cleanup("tun0", splitrt.NewConfig())
+	Cleanup(context.Background(), "tun0", splitrt.NewConfig())
 	want := []string{
 		"resolvectl revert tun0",
 		"ip link delete tun0",


### PR DESCRIPTION
Add package for configuring and running the external executables `ip`, `nft`, `resolvectl` and `sysctl`.
Use it in SplitRouting, TrafPol and VPNSetup and add the executables to the Daemon config.