### PR TITLE
Feature/socket api updates

### DIFF
--- a/internal/api/message.go
+++ b/internal/api/message.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// MaxPayloadLength is the maximum allowed length of a message payload.
-	MaxPayloadLength = 32768
+	MaxPayloadLength = 2097152
 )
 
 // Message types.
@@ -23,7 +23,7 @@ const (
 // Header is a message header.
 type Header struct {
 	Type   uint16
-	Length uint16
+	Length uint32
 }
 
 // Message is an API message.
@@ -40,7 +40,7 @@ func NewMessage(t uint16, p []byte) *Message {
 	return &Message{
 		Header: Header{
 			Type:   t,
-			Length: uint16(len(p)),
+			Length: uint32(len(p)),
 		},
 		Value: p,
 	}

--- a/internal/vpncscript/client.go
+++ b/internal/vpncscript/client.go
@@ -26,6 +26,9 @@ func runClient(socketFile string, configUpdate *daemon.VPNConfigUpdate) error {
 		return fmt.Errorf("VPNCScript could not convert config update to JSON: %w", err)
 	}
 	msg := api.NewMessage(api.TypeVPNConfigUpdate, b)
+	if msg == nil {
+		return fmt.Errorf("VPNCScript could not create message: invalid message")
+	}
 	err = api.WriteMessage(conn, msg)
 	if err != nil {
 		return fmt.Errorf("VPNCScript could not send message to Daemon: %w", err)

--- a/internal/vpncscript/client_test.go
+++ b/internal/vpncscript/client_test.go
@@ -2,10 +2,12 @@ package vpncscript
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/telekom-mms/oc-daemon/internal/api"
 	"github.com/telekom-mms/oc-daemon/internal/daemon"
+	"github.com/telekom-mms/oc-daemon/pkg/vpnconfig"
 )
 
 // TestRunClient tests runClient.
@@ -42,6 +44,58 @@ func TestRunClient(t *testing.T) {
 	}
 	if err := runClient(sockfile, &daemon.VPNConfigUpdate{}); err != nil {
 		t.Fatal(err)
+	}
+	server.Stop()
+
+	// helper for config update creation
+	getConfUpdate := func(length int) *daemon.VPNConfigUpdate {
+		exclude := "a.too.long.example.com"
+		conf := vpnconfig.New()
+		conf.Split.ExcludeDNS = []string{exclude}
+		confUpdate := daemon.NewVPNConfigUpdate()
+		confUpdate.Config = conf
+
+		// check length
+		b, err := confUpdate.JSON()
+		if err != nil {
+			t.Fatal(err)
+		}
+		n := length - len(b)
+
+		// increase length to maximum
+		exclude = strings.Repeat("a", n) + exclude
+		conf.Split.ExcludeDNS = []string{exclude}
+
+		return confUpdate
+	}
+
+	// test with maximum payload length
+	server = api.NewServer(config)
+	go func() {
+		for r := range server.Requests() {
+			r.Close()
+		}
+	}()
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := runClient(sockfile, getConfUpdate(api.MaxPayloadLength)); err != nil {
+		t.Fatal(err)
+	}
+	server.Stop()
+
+	// test with more than maximum payload length
+	server = api.NewServer(config)
+	go func() {
+		for r := range server.Requests() {
+			r.Close()
+		}
+	}()
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := runClient(sockfile, getConfUpdate(api.MaxPayloadLength+1)); err == nil {
+		t.Fatal("too long message should return error")
 	}
 	server.Stop()
 }


### PR DESCRIPTION
Socket API updates:
- Further increase the maximum payload length in API messages to 2MB
- Make sure a Socket API message was created successfully in vpncscript to avoid a panic
- Add tests for the maximum payload length to vpncscript