### PR TITLE
Avoid overlapping split excludes in Split Routing

### DIFF
--- a/internal/splitrt/excludes_test.go
+++ b/internal/splitrt/excludes_test.go
@@ -11,12 +11,9 @@ import (
 )
 
 // getTestExcludes returns excludes for testing.
-func getTestExcludes(t *testing.T) []*net.IPNet {
+func getTestExcludes(t *testing.T, es []string) []*net.IPNet {
 	excludes := []*net.IPNet{}
-	for _, s := range []string{
-		"192.168.1.0/24",
-		"2001::/64",
-	} {
+	for _, s := range es {
 		_, exclude, err := net.ParseCIDR(s)
 		if err != nil {
 			t.Fatal(err)
@@ -26,11 +23,48 @@ func getTestExcludes(t *testing.T) []*net.IPNet {
 	return excludes
 }
 
+// getTestStaticExcludes returns static excludes for testing.
+func getTestStaticExcludes(t *testing.T) []*net.IPNet {
+	return getTestExcludes(t, []string{
+		"192.168.1.0/24",
+		"2001::/64",
+	})
+}
+
+// getTestStaticExcludesOverlap returns static excludes that overlap for testing.
+func getTestStaticExcludesOverlap(t *testing.T) []*net.IPNet {
+	return getTestExcludes(t, []string{
+		"192.168.1.0/26",
+		"192.168.1.64/26",
+		"192.168.1.128/26",
+		"192.168.1.192/26",
+		"192.168.1.0/25",
+		"192.168.1.128/25",
+		"192.168.1.0/24",
+		"2001:2001:2001:2000::/64",
+		"2001:2001:2001:2001::/64",
+		"2001:2001:2001:2002::/64",
+		"2001:2001:2001:2003::/64",
+		"2001:2001:2001:2000::/63",
+		"2001:2001:2001:2002::/63",
+		"2001:2001:2001:2000::/56",
+	})
+}
+
+// getTestDynamicExcludes returns dynamic excludes for testing.
+func getTestDynamicExcludes(t *testing.T) []*net.IPNet {
+	return getTestExcludes(t, []string{
+		"192.168.1.1/32",
+		"2001::1/128",
+		"172.16.1.1/32",
+	})
+}
+
 // TestExcludesAddStatic tests AddStatic of Excludes.
 func TestExcludesAddStatic(t *testing.T) {
 	ctx := context.Background()
 	e := NewExcludes()
-	excludes := getTestExcludes(t)
+	excludes := getTestStaticExcludes(t)
 
 	// set testing runNft function
 	got := []string{}
@@ -57,6 +91,17 @@ func TestExcludesAddStatic(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// test adding overlapping excludes
+	e = NewExcludes()
+	for _, exclude := range getTestStaticExcludesOverlap(t) {
+		e.AddStatic(ctx, exclude)
+	}
+	for k := range e.s {
+		if k != "192.168.1.0/24" && k != "2001:2001:2001:2000::/56" {
+			t.Errorf("unexpected key: %s", k)
+		}
 	}
 }
 
@@ -64,7 +109,7 @@ func TestExcludesAddStatic(t *testing.T) {
 func TestExcludesAddDynamic(t *testing.T) {
 	ctx := context.Background()
 	e := NewExcludes()
-	excludes := getTestExcludes(t)
+	excludes := getTestDynamicExcludes(t)
 
 	// set testing runNft function
 	got := []string{}
@@ -75,8 +120,9 @@ func TestExcludesAddDynamic(t *testing.T) {
 
 	// test adding excludes
 	want := []string{
-		"add element inet oc-daemon-routing excludes4 { 192.168.1.0/24 }",
-		"add element inet oc-daemon-routing excludes6 { 2001::/64 }",
+		"add element inet oc-daemon-routing excludes4 { 192.168.1.1/32 }",
+		"add element inet oc-daemon-routing excludes6 { 2001::1/128 }",
+		"add element inet oc-daemon-routing excludes4 { 172.16.1.1/32 }",
 	}
 	for _, exclude := range excludes {
 		e.AddDynamic(ctx, exclude, 300)
@@ -92,13 +138,41 @@ func TestExcludesAddDynamic(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
+
+	// test adding excludes with existing static excludes,
+	// should only add new excludes
+	e = NewExcludes()
+	for _, exclude := range getTestStaticExcludes(t) {
+		e.AddStatic(ctx, exclude)
+	}
+	got = []string{}
+	want = []string{
+		"add element inet oc-daemon-routing excludes4 { 172.16.1.1/32 }",
+	}
+	for _, exclude := range excludes {
+		e.AddDynamic(ctx, exclude, 300)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// test adding invalid excludes (static as dynamic)
+	e = NewExcludes()
+	got = []string{}
+	want = []string{}
+	for _, exclude := range getTestStaticExcludes(t) {
+		e.AddDynamic(ctx, exclude, 300)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
 }
 
-// TestExcludesRemove tests Remove of Excludes.
+// TestExcludesRemoveStatic tests RemoveStatic of Excludes.
 func TestExcludesRemove(t *testing.T) {
 	ctx := context.Background()
 	e := NewExcludes()
-	excludes := getTestExcludes(t)
+	excludes := getTestStaticExcludes(t)
 
 	// set testing runNft function
 	got := []string{}
@@ -117,7 +191,7 @@ func TestExcludesRemove(t *testing.T) {
 			"flush set inet oc-daemon-routing excludes6\n",
 	}
 	for _, exclude := range excludes {
-		e.Remove(ctx, exclude)
+		e.RemoveStatic(ctx, exclude)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -138,20 +212,7 @@ func TestExcludesRemove(t *testing.T) {
 		e.AddStatic(ctx, exclude)
 	}
 	for _, exclude := range excludes {
-		e.Remove(ctx, exclude)
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-
-	// test removing dynamic excludes
-	// should have same nft commands as static case
-	got = []string{}
-	for _, exclude := range excludes {
-		e.AddDynamic(ctx, exclude, 300)
-	}
-	for _, exclude := range excludes {
-		e.Remove(ctx, exclude)
+		e.RemoveStatic(ctx, exclude)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -167,7 +228,34 @@ func TestExcludesRemove(t *testing.T) {
 		e.AddStatic(ctx, exclude)
 	}
 	for _, exclude := range excludes {
-		e.Remove(ctx, exclude)
+		e.RemoveStatic(ctx, exclude)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// test removing with dynamic excludes
+	got = []string{}
+	want = []string{
+		"add element inet oc-daemon-routing excludes4 { 192.168.1.0/24 }",
+		"add element inet oc-daemon-routing excludes6 { 2001::/64 }",
+		"add element inet oc-daemon-routing excludes4 { 172.16.1.1/32 }",
+		"flush set inet oc-daemon-routing excludes4\n" +
+			"flush set inet oc-daemon-routing excludes6\n" +
+			"add element inet oc-daemon-routing excludes6 { 2001::/64 }\n" +
+			"add element inet oc-daemon-routing excludes4 { 172.16.1.1/32 }\n",
+		"flush set inet oc-daemon-routing excludes4\n" +
+			"flush set inet oc-daemon-routing excludes6\n" +
+			"add element inet oc-daemon-routing excludes4 { 172.16.1.1/32 }\n",
+	}
+	for _, exclude := range excludes {
+		e.AddStatic(ctx, exclude)
+	}
+	for _, exclude := range getTestDynamicExcludes(t) {
+		e.AddDynamic(ctx, exclude, 300)
+	}
+	for _, exclude := range excludes {
+		e.RemoveStatic(ctx, exclude)
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -178,7 +266,6 @@ func TestExcludesRemove(t *testing.T) {
 func TestExcludesCleanup(t *testing.T) {
 	ctx := context.Background()
 	e := NewExcludes()
-	excludes := getTestExcludes(t)
 
 	// set testing runNft function
 	got := []string{}
@@ -195,7 +282,7 @@ func TestExcludesCleanup(t *testing.T) {
 	}
 
 	// test with dynamic excludes
-	for _, exclude := range excludes {
+	for _, exclude := range getTestDynamicExcludes(t) {
 		e.AddDynamic(ctx, exclude, excludesTimer)
 	}
 
@@ -217,7 +304,7 @@ func TestExcludesCleanup(t *testing.T) {
 	}
 
 	// test with static excludes
-	for _, exclude := range excludes {
+	for _, exclude := range getTestStaticExcludes(t) {
 		e.AddStatic(ctx, exclude)
 	}
 	got = []string{}
@@ -238,7 +325,9 @@ func TestExcludesStartStop(_ *testing.T) {
 // TestNewExcludes tests NewExcludes.
 func TestNewExcludes(t *testing.T) {
 	e := NewExcludes()
-	if e.m == nil ||
+	if e == nil ||
+		e.s == nil ||
+		e.d == nil ||
 		e.done == nil ||
 		e.closed == nil {
 

--- a/internal/splitrt/splitrt.go
+++ b/internal/splitrt/splitrt.go
@@ -158,7 +158,7 @@ func (s *SplitRouting) updateLocalNetworkExcludes(ctx context.Context) {
 	// remove old excludes
 	for _, l := range s.locals {
 		if !isIn(l, excludes) {
-			s.excludes.Remove(ctx, l)
+			s.excludes.RemoveStatic(ctx, l)
 		}
 	}
 


### PR DESCRIPTION
Filter out overlapping IP ranges in split excludes in Split Routing to avoid errors when setting the excludes in netfilter.