### PR TITLE
Feature/rework answer handling in dnsproxy

### DIFF
--- a/internal/dnsproxy/proxy.go
+++ b/internal/dnsproxy/proxy.go
@@ -113,8 +113,7 @@ func (p *Proxy) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 		for _, a := range reply.Answer {
 			// ignore domain names we do not watch
 			name := a.Header().Name
-			if !p.watches.Contains(r.Question[0].Name) &&
-				!p.watches.Contains(name) {
+			if !p.watches.Contains(name) {
 				// not on watch list, ignore answer
 				continue
 			}

--- a/internal/dnsproxy/proxy.go
+++ b/internal/dnsproxy/proxy.go
@@ -92,7 +92,7 @@ func (p *Proxy) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 				"target": rr.Target,
 				"ttl":    ttl,
 			}).Debug("DNS-Proxy received CNAME in reply")
-			p.watches.AddTemp(rr.Target, ttl)
+			p.watches.AddTempCNAME(rr.Target, ttl)
 
 		case dns.TypeDNAME:
 			// DNAME record, store temporary watch
@@ -105,7 +105,7 @@ func (p *Proxy) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 				"target": rr.Target,
 				"ttl":    ttl,
 			}).Debug("DNS-Proxy received DNAME in reply")
-			p.watches.AddTemp(rr.Target, ttl)
+			p.watches.AddTempDNAME(rr.Target, ttl)
 		}
 	}
 

--- a/internal/dnsproxy/watches.go
+++ b/internal/dnsproxy/watches.go
@@ -146,9 +146,8 @@ func (w *Watches) Contains(domain string) bool {
 	// get label indexes and find matching domains
 	labels := dns.Split(domain)
 	if labels == nil {
-		// root domain
-		// TODO: remove temp domain check here?
-		return w.m["."] || w.c["."] != nil || w.d["."] != nil
+		// root domain, not supported in watch list
+		return false
 	}
 
 	// try finding exact domain name in temporary CNAMEs

--- a/internal/dnsproxy/watches_test.go
+++ b/internal/dnsproxy/watches_test.go
@@ -121,7 +121,6 @@ func TestWatchesContains(t *testing.T) {
 		w := NewWatches()
 		defer w.Close()
 		w.Add("example.com.")
-		w.Add(".")
 
 		// test invalid domain name
 		invalid := "this is not a domain name..."
@@ -130,15 +129,9 @@ func TestWatchesContains(t *testing.T) {
 				w.Contains(invalid), invalid)
 		}
 
-		// test root domain
-		root := "."
-		if !w.Contains(root) {
-			t.Errorf("got %t, want true (domain: %s)",
-				w.Contains(root), root)
-		}
-
 		// try not matching (sub)domain
 		for _, domain := range []string{
+			".",
 			"test.com.",
 			"sub.test.com.",
 			"sub.sub.test.com.",
@@ -168,10 +161,10 @@ func TestWatchesContains(t *testing.T) {
 		w := NewWatches()
 		defer w.Close()
 		w.AddTempCNAME("example.com.", 500)
-		w.AddTempCNAME(".", 500)
 
 		// try not matching (sub)domain
 		for _, domain := range []string{
+			".",
 			"test.com.",
 			"sub.test.com.",
 			"sub.sub.test.com.",
@@ -189,7 +182,6 @@ func TestWatchesContains(t *testing.T) {
 		// try matching domain
 		for _, domain := range []string{
 			"example.com.",
-			".",
 		} {
 			if !w.Contains(domain) {
 				t.Errorf("got %t, want true (domain: %s)",
@@ -202,10 +194,10 @@ func TestWatchesContains(t *testing.T) {
 		w := NewWatches()
 		defer w.Close()
 		w.AddTempDNAME("example.com.", 500)
-		w.AddTempDNAME(".", 500)
 
 		// try not matching (sub)domain
 		for _, domain := range []string{
+			".",
 			"test.com.",
 			"sub.test.com.",
 			"sub.sub.test.com.",
@@ -223,7 +215,6 @@ func TestWatchesContains(t *testing.T) {
 			"sub.example.com.",
 			"sub.sub.example.com.",
 			"sub.sub.sub.example.com.",
-			".",
 		} {
 			if !w.Contains(domain) {
 				t.Errorf("got %t, want true (domain: %s)",

--- a/internal/dnsproxy/watches_test.go
+++ b/internal/dnsproxy/watches_test.go
@@ -13,13 +13,25 @@ func TestWatchesAdd(t *testing.T) {
 	}
 }
 
-// TestWatchesAddTemp tests AddTemp of Watches.
-func TestWatchesAddTemp(t *testing.T) {
+// TestWatchesAddTempCNAME tests AddTempCNAME of Watches.
+func TestWatchesAddTempCNAME(t *testing.T) {
 	w := NewWatches()
 	defer w.Close()
 	domain := "example.com."
 	ttl := uint32(300)
-	w.AddTemp(domain, ttl)
+	w.AddTempCNAME(domain, ttl)
+	if !w.Contains(domain) {
+		t.Errorf("got %t, want true", w.Contains(domain))
+	}
+}
+
+// TestWatchesAddTempDNAME tests AddTempDNAME of Watches.
+func TestWatchesAddTempDNAME(t *testing.T) {
+	w := NewWatches()
+	defer w.Close()
+	domain := "example.com."
+	ttl := uint32(300)
+	w.AddTempDNAME(domain, ttl)
 	if !w.Contains(domain) {
 		t.Errorf("got %t, want true", w.Contains(domain))
 	}
@@ -39,8 +51,15 @@ func TestWatchesRemove(t *testing.T) {
 		t.Errorf("got %t, want false", w.Contains(domain))
 	}
 
-	// test temporary domain
-	w.AddTemp(domain, ttl)
+	// test temporary CNAME domain
+	w.AddTempCNAME(domain, ttl)
+	w.Remove(domain)
+	if w.Contains(domain) {
+		t.Errorf("got %t, want false", w.Contains(domain))
+	}
+
+	// test temporary DNAME domain
+	w.AddTempDNAME(domain, ttl)
 	w.Remove(domain)
 	if w.Contains(domain) {
 		t.Errorf("got %t, want false", w.Contains(domain))
@@ -54,9 +73,10 @@ func TestWatchesCleanTemp(t *testing.T) {
 	domain := "example.com."
 	interval := uint32(15)
 
-	// test different ttls
+	// test temporary CNAMEs and DNAMEs with different ttls
 	for _, ttl := range []uint32{0, interval - 1, interval, interval + 1, 3 * interval} {
-		w.AddTemp(domain, ttl)
+		w.AddTempCNAME(domain, ttl)
+		w.AddTempDNAME(domain, ttl)
 
 		// cleanups with element staying in watches
 		for i := uint32(0); i <= ttl; i += interval {
@@ -79,14 +99,17 @@ func TestWatchesFlush(t *testing.T) {
 	w := NewWatches()
 	defer w.Close()
 	domain := "sub.example.com."
-	tempDomain := "temp.example.com."
+	tempCNAME := "temp.cname.example.com."
+	tempDNAME := "temp.dname.example.com."
 	ttl := uint32(300)
 
 	w.Add(domain)
-	w.AddTemp(tempDomain, ttl)
+	w.AddTempCNAME(tempCNAME, ttl)
+	w.AddTempDNAME(tempDNAME, ttl)
 	w.Flush()
 	if w.Contains(domain) ||
-		w.Contains(tempDomain) {
+		w.Contains(tempCNAME) ||
+		w.Contains(tempDNAME) {
 
 		t.Errorf("got true, want false")
 	}
@@ -94,53 +117,128 @@ func TestWatchesFlush(t *testing.T) {
 
 // TestWatchesContains tests Contains of Watches.
 func TestWatchesContains(t *testing.T) {
-	w := NewWatches()
-	defer w.Close()
-	w.Add("example.com.")
-	w.Add(".")
+	t.Run("regular watches", func(t *testing.T) {
+		w := NewWatches()
+		defer w.Close()
+		w.Add("example.com.")
+		w.Add(".")
 
-	// test invalid domain name
-	invalid := "this is not a domain name!"
-	if w.Contains(invalid) {
-		t.Errorf("got %t, want false (domain: %s)", w.Contains(invalid), invalid)
-	}
-
-	// test root domain
-	root := "."
-	if !w.Contains(root) {
-		t.Errorf("got %t, want true (domain: %s)", w.Contains(root), root)
-	}
-
-	// try not matching (sub)domain
-	for _, domain := range []string{
-		"test.com.",
-		"sub.test.com.",
-		"sub.sub.test.com.",
-		"sub.sub.sub.test.com.",
-	} {
-		if w.Contains(domain) {
-			t.Errorf("got %t, want false (domain: %s)", w.Contains(domain), domain)
+		// test invalid domain name
+		invalid := "this is not a domain name..."
+		if w.Contains(invalid) {
+			t.Errorf("got %t, want false (domain: %s)",
+				w.Contains(invalid), invalid)
 		}
-	}
 
-	// try matching (sub)domain
-	for _, domain := range []string{
-		"example.com.",
-		"sub.example.com.",
-		"sub.sub.example.com.",
-		"sub.sub.sub.example.com.",
-	} {
-		if !w.Contains(domain) {
-			t.Errorf("got %t, want true (domain: %s)", w.Contains(domain), domain)
+		// test root domain
+		root := "."
+		if !w.Contains(root) {
+			t.Errorf("got %t, want true (domain: %s)",
+				w.Contains(root), root)
 		}
-	}
+
+		// try not matching (sub)domain
+		for _, domain := range []string{
+			"test.com.",
+			"sub.test.com.",
+			"sub.sub.test.com.",
+			"sub.sub.sub.test.com.",
+		} {
+			if w.Contains(domain) {
+				t.Errorf("got %t, want false (domain: %s)",
+					w.Contains(domain), domain)
+			}
+		}
+
+		// try matching (sub)domain
+		for _, domain := range []string{
+			"example.com.",
+			"sub.example.com.",
+			"sub.sub.example.com.",
+			"sub.sub.sub.example.com.",
+		} {
+			if !w.Contains(domain) {
+				t.Errorf("got %t, want true (domain: %s)",
+					w.Contains(domain), domain)
+			}
+		}
+	})
+
+	t.Run("temporary CNAMEs", func(t *testing.T) {
+		w := NewWatches()
+		defer w.Close()
+		w.AddTempCNAME("example.com.", 500)
+		w.AddTempCNAME(".", 500)
+
+		// try not matching (sub)domain
+		for _, domain := range []string{
+			"test.com.",
+			"sub.test.com.",
+			"sub.sub.test.com.",
+			"sub.sub.sub.test.com.",
+			"sub.example.com.",
+			"sub.sub.example.com.",
+			"sub.sub.sub.example.com.",
+		} {
+			if w.Contains(domain) {
+				t.Errorf("got %t, want false (domain: %s)",
+					w.Contains(domain), domain)
+			}
+		}
+
+		// try matching domain
+		for _, domain := range []string{
+			"example.com.",
+			".",
+		} {
+			if !w.Contains(domain) {
+				t.Errorf("got %t, want true (domain: %s)",
+					w.Contains(domain), domain)
+			}
+		}
+	})
+
+	t.Run("temporary DNAMEs", func(t *testing.T) {
+		w := NewWatches()
+		defer w.Close()
+		w.AddTempDNAME("example.com.", 500)
+		w.AddTempDNAME(".", 500)
+
+		// try not matching (sub)domain
+		for _, domain := range []string{
+			"test.com.",
+			"sub.test.com.",
+			"sub.sub.test.com.",
+			"sub.sub.sub.test.com.",
+		} {
+			if w.Contains(domain) {
+				t.Errorf("got %t, want false (domain: %s)",
+					w.Contains(domain), domain)
+			}
+		}
+
+		// try matching (sub)domain
+		for _, domain := range []string{
+			"example.com.",
+			"sub.example.com.",
+			"sub.sub.example.com.",
+			"sub.sub.sub.example.com.",
+			".",
+		} {
+			if !w.Contains(domain) {
+				t.Errorf("got %t, want true (domain: %s)",
+					w.Contains(domain), domain)
+			}
+		}
+	})
 }
 
 // TestNewWatches tests NewWatches.
 func TestNewWatches(t *testing.T) {
 	w := NewWatches()
 	if w.m == nil ||
-		w.t == nil {
+		w.c == nil ||
+		w.d == nil {
 
 		t.Errorf("got nil, want != nil")
 	}


### PR DESCRIPTION
Rework DNS answer handling and watch list interaction in DNS Proxy:
- Do not handle CNAME records like DNAME records in watch list: only support exact matches for CNAMEs
- Parse DNAME and CNAME records before A and AAAA records to make sure temporary watches are present
- Only check answer domain names in watch list and ignore question domain names
- Remove support for root domain (".") from watch list