### PR TITLE
Fix linter warnings in tests

### DIFF
--- a/internal/addrmon/addrmon_test.go
+++ b/internal/addrmon/addrmon_test.go
@@ -19,8 +19,8 @@ func TestAddrMonStartStop(t *testing.T) {
 	// test RegisterAddrUpdates without netlink error
 	addrMon := NewAddrMon()
 
-	netlinkAddrSubscribeWithOptions = func(ch chan<- netlink.AddrUpdate,
-		done <-chan struct{}, options netlink.AddrSubscribeOptions) error {
+	netlinkAddrSubscribeWithOptions = func(chan<- netlink.AddrUpdate,
+		<-chan struct{}, netlink.AddrSubscribeOptions) error {
 		return nil
 	}
 
@@ -32,7 +32,7 @@ func TestAddrMonStartStop(t *testing.T) {
 	// test without AddrUpdates
 	addrMon = NewAddrMon()
 
-	RegisterAddrUpdates = func(a *AddrMon) (chan netlink.AddrUpdate, error) {
+	RegisterAddrUpdates = func(*AddrMon) (chan netlink.AddrUpdate, error) {
 		return nil, nil
 	}
 

--- a/internal/cpd/cpd_test.go
+++ b/internal/cpd/cpd_test.go
@@ -12,7 +12,7 @@ import (
 func TestCPDProbeCheck(t *testing.T) {
 	// probe with status code 400 (-> detected) and early stop
 	t.Run("stop during probe", func(_ *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 		}))
 		defer ts.Close()
@@ -25,7 +25,7 @@ func TestCPDProbeCheck(t *testing.T) {
 
 	// check with redirect and no url
 	t.Run("redirect without url", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusFound)
 		}))
 		defer ts.Close()
@@ -53,7 +53,7 @@ func TestCPDProbeCheck(t *testing.T) {
 
 	// check with invalid content length
 	t.Run("invalid content length", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Length", "100")
 			w.WriteHeader(http.StatusOK)
 		}))
@@ -167,7 +167,7 @@ func TestCPDHosts(t *testing.T) {
 func TestCPDProbe(t *testing.T) {
 	// status code 204, not detected
 	t.Run("not detected", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNoContent)
 		}))
 		defer ts.Close()

--- a/internal/dbusapi/service_test.go
+++ b/internal/dbusapi/service_test.go
@@ -221,13 +221,13 @@ func TestServiceStartStop(t *testing.T) {
 	}()
 
 	// no errors
-	dbusConnectSystemBus = func(opts ...dbus.ConnOption) (dbusConn, error) {
+	dbusConnectSystemBus = func(...dbus.ConnOption) (dbusConn, error) {
 		return &testConn{
 			reqNameReply: dbus.RequestNameReplyPrimaryOwner,
 			exportOKNum:  2,
 		}, nil
 	}
-	propExport = func(conn dbusConn, path dbus.ObjectPath, props prop.Map) (propProperties, error) {
+	propExport = func(dbusConn, dbus.ObjectPath, prop.Map) (propProperties, error) {
 		return &testProperties{}, nil
 	}
 	s := NewService()
@@ -237,7 +237,7 @@ func TestServiceStartStop(t *testing.T) {
 	s.Stop()
 
 	// conn export introspectable error
-	dbusConnectSystemBus = func(opts ...dbus.ConnOption) (dbusConn, error) {
+	dbusConnectSystemBus = func(...dbus.ConnOption) (dbusConn, error) {
 		return &testConn{
 			reqNameReply: dbus.RequestNameReplyPrimaryOwner,
 			exportOKNum:  1,
@@ -250,7 +250,7 @@ func TestServiceStartStop(t *testing.T) {
 	}
 
 	// props export error
-	propExport = func(conn dbusConn, path dbus.ObjectPath, props prop.Map) (propProperties, error) {
+	propExport = func(dbusConn, dbus.ObjectPath, prop.Map) (propProperties, error) {
 		return nil, errors.New("test error")
 	}
 	s = NewService()
@@ -259,7 +259,7 @@ func TestServiceStartStop(t *testing.T) {
 	}
 
 	// conn export methods error
-	dbusConnectSystemBus = func(opts ...dbus.ConnOption) (dbusConn, error) {
+	dbusConnectSystemBus = func(...dbus.ConnOption) (dbusConn, error) {
 		return &testConn{
 			reqNameReply: dbus.RequestNameReplyPrimaryOwner,
 			exportError:  errors.New("test error"),
@@ -271,7 +271,7 @@ func TestServiceStartStop(t *testing.T) {
 	}
 
 	// bus name alredy taken
-	dbusConnectSystemBus = func(opts ...dbus.ConnOption) (dbusConn, error) {
+	dbusConnectSystemBus = func(...dbus.ConnOption) (dbusConn, error) {
 		return &testConn{
 			reqNameReply: dbus.RequestNameReplyExists,
 		}, nil
@@ -282,7 +282,7 @@ func TestServiceStartStop(t *testing.T) {
 	}
 
 	// conn request name error
-	dbusConnectSystemBus = func(opts ...dbus.ConnOption) (dbusConn, error) {
+	dbusConnectSystemBus = func(...dbus.ConnOption) (dbusConn, error) {
 		return &testConn{
 			reqNameError: errors.New("test error"),
 		}, nil
@@ -293,7 +293,7 @@ func TestServiceStartStop(t *testing.T) {
 	}
 
 	// dbus connect error
-	dbusConnectSystemBus = func(opts ...dbus.ConnOption) (dbusConn, error) {
+	dbusConnectSystemBus = func(...dbus.ConnOption) (dbusConn, error) {
 		return nil, errors.New("test error")
 	}
 	s = NewService()
@@ -322,14 +322,14 @@ func TestServiceSetProperty(t *testing.T) {
 		propExport = oldPropExport
 	}()
 
-	dbusConnectSystemBus = func(opts ...dbus.ConnOption) (dbusConn, error) {
+	dbusConnectSystemBus = func(...dbus.ConnOption) (dbusConn, error) {
 		return &testConn{
 			reqNameReply: dbus.RequestNameReplyPrimaryOwner,
 			exportOKNum:  2,
 		}, nil
 	}
 	properties := &testProperties{props: make(map[string]any)}
-	propExport = func(conn dbusConn, path dbus.ObjectPath, props prop.Map) (propProperties, error) {
+	propExport = func(dbusConn, dbus.ObjectPath, prop.Map) (propProperties, error) {
 		return properties, nil
 	}
 	s := NewService()

--- a/internal/devmon/devmon_test.go
+++ b/internal/devmon/devmon_test.go
@@ -11,7 +11,7 @@ import (
 // TestDevMonStartStop tests Start and Stop of DevMon.
 func TestDevMonStartStop(t *testing.T) {
 	// test without LinkUpdates
-	RegisterLinkUpdates = func(d *DevMon) (chan netlink.LinkUpdate, error) {
+	RegisterLinkUpdates = func(*DevMon) (chan netlink.LinkUpdate, error) {
 		return nil, nil
 	}
 
@@ -84,7 +84,7 @@ func TestDevMonStartStop(t *testing.T) {
 		// send test update in goroutine spawned in RegisterLinkUpdates
 		// and signal sending complete
 		sendDone := make(chan struct{})
-		RegisterLinkUpdates = func(d *DevMon) (chan netlink.LinkUpdate, error) {
+		RegisterLinkUpdates = func(*DevMon) (chan netlink.LinkUpdate, error) {
 			updates := make(chan netlink.LinkUpdate)
 			go func(up netlink.LinkUpdate) {
 				defer close(sendDone)
@@ -137,7 +137,7 @@ func TestDevMonStartStop(t *testing.T) {
 
 	// test with unexpected close and LinkUpdates
 	runOnce := false
-	RegisterLinkUpdates = func(d *DevMon) (chan netlink.LinkUpdate, error) {
+	RegisterLinkUpdates = func(*DevMon) (chan netlink.LinkUpdate, error) {
 		updates := make(chan netlink.LinkUpdate)
 		if !runOnce {
 			// on first run, close updates

--- a/internal/execs/execs_test.go
+++ b/internal/execs/execs_test.go
@@ -47,7 +47,7 @@ func TestRunIP(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -65,7 +65,7 @@ func TestRunIPLink(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -83,7 +83,7 @@ func TestRunIPAddress(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -101,7 +101,7 @@ func TestRunIP4Route(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -119,7 +119,7 @@ func TestRunIP6Route(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -137,7 +137,7 @@ func TestRunIP4Rule(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -155,7 +155,7 @@ func TestRunIP6Rule(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -173,7 +173,7 @@ func TestRunSysctl(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -191,7 +191,7 @@ func TestRunNft(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " ")+" "+s)
 		return nil, nil, nil
 	}
@@ -209,7 +209,7 @@ func TestRunResolvectl(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := RunCmd
-	RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	RunCmd = func(_ context.Context, cmd string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, cmd+" "+strings.Join(arg, " "))
 		return []byte("OK"), nil, nil
 	}

--- a/internal/sleepmon/sleepmon_test.go
+++ b/internal/sleepmon/sleepmon_test.go
@@ -63,7 +63,7 @@ func TestSleepMonStartEvents(t *testing.T) {
 func TestSleepMonStartErrors(t *testing.T) {
 	// match signal error
 	oldAddMatchSignal := connAddMatchSignal
-	connAddMatchSignal = func(conn *dbus.Conn, options ...dbus.MatchOption) error {
+	connAddMatchSignal = func(*dbus.Conn, ...dbus.MatchOption) error {
 		return errors.New("test error")
 	}
 	defer func() { connAddMatchSignal = oldAddMatchSignal }()
@@ -74,7 +74,7 @@ func TestSleepMonStartErrors(t *testing.T) {
 	}
 
 	// system bus error
-	dbusConnectSystemBus = func(opts ...dbus.ConnOption) (*dbus.Conn, error) {
+	dbusConnectSystemBus = func(...dbus.ConnOption) (*dbus.Conn, error) {
 		return nil, errors.New("test error")
 	}
 	defer func() { dbusConnectSystemBus = dbus.ConnectSystemBus }()

--- a/internal/splitrt/excludes_test.go
+++ b/internal/splitrt/excludes_test.go
@@ -68,7 +68,7 @@ func TestExcludesAddStatic(t *testing.T) {
 
 	// set testing runNft function
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}
@@ -113,7 +113,7 @@ func TestExcludesAddDynamic(t *testing.T) {
 
 	// set testing runNft function
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}
@@ -177,7 +177,7 @@ func TestExcludesRemove(t *testing.T) {
 	// set testing runNft function
 	got := []string{}
 	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}
@@ -220,7 +220,7 @@ func TestExcludesRemove(t *testing.T) {
 
 	// test with nft error
 	got = []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, errors.New("test error")
 	}
@@ -269,7 +269,7 @@ func TestExcludesCleanup(t *testing.T) {
 
 	// set testing runNft function
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}

--- a/internal/splitrt/splitrt_test.go
+++ b/internal/splitrt/splitrt_test.go
@@ -25,7 +25,7 @@ func TestSplitRoutingHandleDeviceUpdate(t *testing.T) {
 	got := []string{"nothing else"}
 
 	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}
@@ -79,7 +79,7 @@ func TestSplitRoutingHandleAddressUpdate(t *testing.T) {
 
 	got := []string{}
 	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}
@@ -159,7 +159,7 @@ func TestSplitRoutingHandleDNSReport(t *testing.T) {
 
 	got := []string{}
 	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}
@@ -188,7 +188,7 @@ func TestSplitRoutingHandleDNSReport(t *testing.T) {
 func TestSplitRoutingStartStop(t *testing.T) {
 	// set dummy low level functions for testing
 	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(context.Context, string, string, ...string) ([]byte, []byte, error) {
 		return nil, nil, nil
 	}
 	defer func() { execs.RunCmd = oldRunCmd }()
@@ -263,7 +263,7 @@ func TestSplitRoutingStartStop(t *testing.T) {
 	s.Stop()
 
 	// test with nft errors
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(context.Context, string, string, ...string) ([]byte, []byte, error) {
 		return nil, nil, errors.New("test error")
 	}
 	s = NewSplitRouting(NewConfig(), vpnconfig.New())
@@ -312,7 +312,7 @@ func TestCleanup(t *testing.T) {
 	got := []string{}
 
 	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
 		if s == "" {
 			got = append(got, cmd+" "+strings.Join(arg, " "))
 			return nil, nil, nil

--- a/internal/trafpol/allowdevs_test.go
+++ b/internal/trafpol/allowdevs_test.go
@@ -14,7 +14,7 @@ func TestAllowDevsAdd(t *testing.T) {
 	ctx := context.Background()
 
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}
@@ -42,7 +42,7 @@ func TestAllowDevsRemove(t *testing.T) {
 	ctx := context.Background()
 
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}

--- a/internal/trafpol/filter_test.go
+++ b/internal/trafpol/filter_test.go
@@ -12,7 +12,7 @@ import (
 // TestFilterFunctionsErrors tests filter functions, errors.
 func TestFilterFunctionsErrors(_ *testing.T) {
 	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(context.Context, string, string, ...string) ([]byte, []byte, error) {
 		return nil, nil, errors.New("test error")
 	}
 	defer func() { execs.RunCmd = oldRunCmd }()

--- a/internal/trafpol/trafpol_test.go
+++ b/internal/trafpol/trafpol_test.go
@@ -51,7 +51,7 @@ func TestTrafPolHandleCPDReport(t *testing.T) {
 	var nftMutex sync.Mutex
 	nftCmds := []string{}
 	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		nftMutex.Lock()
 		defer nftMutex.Unlock()
 		nftCmds = append(nftCmds, s)
@@ -157,7 +157,7 @@ func TestCleanup(t *testing.T) {
 		"delete table inet oc-daemon-filter",
 	}
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
 		got = append(got, s)
 		return nil, nil, nil
 	}

--- a/internal/vpnsetup/vpnsetup_test.go
+++ b/internal/vpnsetup/vpnsetup_test.go
@@ -40,7 +40,7 @@ func TestSetupVPNDevice(t *testing.T) {
 		"address add 2001::1/64 dev tun0",
 	}
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -57,7 +57,7 @@ func TestSetupVPNDevice(t *testing.T) {
 	// depending on when execs.RunCmd failed.
 	numRuns := 0
 	failAt := 0
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, _ string, arg ...string) ([]byte, []byte, error) {
 		// fail after failAt runs
 		if numRuns == failAt {
 			return nil, nil, errors.New("test error")
@@ -93,7 +93,7 @@ func TestTeardownVPNDevice(t *testing.T) {
 		"link set tun0 down",
 	}
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -105,7 +105,7 @@ func TestTeardownVPNDevice(t *testing.T) {
 	}
 
 	// test with execs error
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(context.Context, string, string, ...string) ([]byte, []byte, error) {
 		return nil, nil, errors.New("test error")
 	}
 	teardownVPNDevice(context.Background(), c)
@@ -122,7 +122,7 @@ func TestVPNSetupSetupDNS(t *testing.T) {
 	c.DNS.DefaultDomain = "mycompany.com"
 
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -141,7 +141,7 @@ func TestVPNSetupSetupDNS(t *testing.T) {
 	}
 
 	// test with execs errors
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, strings.Join(arg, " "))
 		return nil, nil, errors.New("test error")
 	}
@@ -163,7 +163,7 @@ func TestVPNSetupTeardownDNS(t *testing.T) {
 	c.Device.Name = "tun0"
 
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, strings.Join(arg, " "))
 		return nil, nil, nil
 	}
@@ -181,7 +181,7 @@ func TestVPNSetupTeardownDNS(t *testing.T) {
 	}
 
 	// test with execs errors
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, _ string, _ string, arg ...string) ([]byte, []byte, error) {
 		got = append(got, strings.Join(arg, " "))
 		return nil, nil, errors.New("test error")
 	}
@@ -282,7 +282,7 @@ func TestVPNSetupEnsureDNS(t *testing.T) {
 	vpnconf.DNS.DefaultDomain = "test.example.com"
 
 	// test resolvectl error
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(context.Context, string, string, ...string) ([]byte, []byte, error) {
 		return nil, nil, errors.New("test error")
 	}
 
@@ -299,7 +299,7 @@ func TestVPNSetupEnsureDNS(t *testing.T) {
 		[]byte("header\nProtocols: +DefaultRoute\nDNS Servers: other\nDNS Domain: test.example.com ~.\n"),
 		[]byte("header\nProtocols: +DefaultRoute\nDNS Servers: 127.0.0.1:4253\nDNS Domain: other\n"),
 	} {
-		execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+		execs.RunCmd = func(context.Context, string, string, ...string) ([]byte, []byte, error) {
 			return invalid, nil, nil
 		}
 
@@ -314,7 +314,7 @@ func TestVPNSetupEnsureDNS(t *testing.T) {
 		[]byte("header\n Protocols:  +DefaultRoute  \nother\n  " +
 			"DNS Servers: 127.0.0.1:4253  \n  DNS Domain: test.example.com ~.\nother\n"),
 	} {
-		execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+		execs.RunCmd = func(context.Context, string, string, ...string) ([]byte, []byte, error) {
 			return valid, nil, nil
 		}
 
@@ -335,7 +335,7 @@ func TestVPNSetupStartStop(_ *testing.T) {
 func TestVPNSetupSetupTeardown(_ *testing.T) {
 	// override functions
 	oldCmd := execs.RunCmd
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(context.Context, string, string, ...string) ([]byte, []byte, error) {
 		return nil, nil, nil
 	}
 	defer func() { execs.RunCmd = oldCmd }()
@@ -410,7 +410,7 @@ func TestNewVPNSetup(t *testing.T) {
 // TestCleanup tests Cleanup.
 func TestCleanup(t *testing.T) {
 	got := []string{}
-	execs.RunCmd = func(ctx context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
+	execs.RunCmd = func(_ context.Context, cmd string, s string, arg ...string) ([]byte, []byte, error) {
 		if s == "" {
 			got = append(got, cmd+" "+strings.Join(arg, " "))
 			return nil, nil, nil

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -144,7 +144,7 @@ func TestDBusClientSubscribe(t *testing.T) {
 	connAddMatchSignal = func(*dbus.Conn, ...dbus.MatchOption) error {
 		return nil
 	}
-	connSignal = func(conn *dbus.Conn, ch chan<- *dbus.Signal) {}
+	connSignal = func(*dbus.Conn, chan<- *dbus.Signal) {}
 
 	client := &DBusClient{
 		updates: make(chan *vpnstatus.Status),
@@ -342,7 +342,7 @@ func TestDBusClientConnect(t *testing.T) {
 	query = func(*DBusClient) (map[string]dbus.Variant, error) {
 		return nil, nil
 	}
-	connect = func(d *DBusClient) error {
+	connect = func(*DBusClient) error {
 		return nil
 	}
 	if err := client.Connect(); err != nil {
@@ -386,7 +386,7 @@ func TestDBusClientDisconnect(t *testing.T) {
 		}
 		return props, nil
 	}
-	disconnect = func(d *DBusClient) error {
+	disconnect = func(*DBusClient) error {
 		return nil
 	}
 	err := client.Disconnect()


### PR DESCRIPTION
Fix unused parameter warnings of the revive linter in tests by removing unused parameter variables or replacing them with `_`.