### PR TITLE
Fix linter warnings

### DIFF
--- a/internal/cpd/cpd.go
+++ b/internal/cpd/cpd.go
@@ -41,7 +41,7 @@ func (c *CPD) check() *Report {
 	// send http request
 	client := &http.Client{
 		Timeout: c.config.HTTPTimeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -538,7 +538,7 @@ func (d *Daemon) setTNDDialer() {
 	}
 
 	// control function that sets socket option on raw connection
-	control := func(network, address string, c syscall.RawConn) error {
+	control := func(_, _ string, c syscall.RawConn) error {
 		// set socket option function for setting mark with SO_MARK
 		var soerr error
 		setsockopt := func(fd uintptr) {


### PR DESCRIPTION
Fix unused parameter warnings of the revive linter by removing unused parameter variables or replacing them with `_`.