### PR TITLE
Improve handling of DNS Proxy reports

### DIFF
--- a/internal/dnsproxy/proxy.go
+++ b/internal/dnsproxy/proxy.go
@@ -28,6 +28,14 @@ func (p *Proxy) sendReport(report *Report) {
 	}
 }
 
+// waitReport waits for report to finish.
+func (p *Proxy) waitReport(report *Report) {
+	select {
+	case <-report.Done():
+	case <-p.done:
+	}
+}
+
 // handleRequest handles a dns client request.
 func (p *Proxy) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 	// make sure the client request is valid
@@ -95,7 +103,7 @@ func (p *Proxy) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 		}
 		report := NewReport(rr.Hdr.Name, rr.A, rr.Hdr.Ttl)
 		p.sendReport(report)
-		report.Wait()
+		p.waitReport(report)
 	}
 
 	// handler for AAAA answers
@@ -108,7 +116,7 @@ func (p *Proxy) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 		}
 		report := NewReport(rr.Hdr.Name, rr.AAAA, rr.Hdr.Ttl)
 		p.sendReport(report)
-		report.Wait()
+		p.waitReport(report)
 	}
 
 	// handle DNAME and CNAME records before A and AAAA records to make

--- a/internal/dnsproxy/proxy_test.go
+++ b/internal/dnsproxy/proxy_test.go
@@ -107,7 +107,7 @@ func TestProxyHandleRequest(t *testing.T) {
 		defer close(reportsDone)
 		for r := range p.Reports() {
 			reports = append(reports, r)
-			r.Done()
+			r.Close()
 		}
 	}()
 	p.handleRequest(&responseWriter{}, &dns.Msg{Question: []dns.Question{{Name: "test.example.com."}}})
@@ -185,7 +185,7 @@ func TestProxyHandleRequestRecords(t *testing.T) {
 			defer close(reportsDone)
 			for r := range p.Reports() {
 				reports = append(reports, r)
-				r.Done()
+				r.Close()
 			}
 		}()
 

--- a/internal/dnsproxy/report.go
+++ b/internal/dnsproxy/report.go
@@ -13,7 +13,6 @@ type Report struct {
 
 	// done is used to signal that the report has been handled by
 	// its consumer
-	// TODO: check if this is OK for us
 	done chan struct{}
 }
 
@@ -22,14 +21,14 @@ func (r *Report) String() string {
 	return fmt.Sprintf("%s -> %s (ttl: %d)", r.Name, r.IP, r.TTL)
 }
 
-// Done signals that the report has been handled by its consumer.
-func (r *Report) Done() {
-	r.done <- struct{}{}
+// Close signals that the report has been handled by its consumer.
+func (r *Report) Close() {
+	close(r.done)
 }
 
-// Wait waits for the report to be handled by its consumer.
-func (r *Report) Wait() {
-	<-r.done
+// Done returns a channel that is closed when the report was handled by its consumer.
+func (r *Report) Done() <-chan struct{} {
+	return r.done
 }
 
 // NewReport returns a new report with domain name, IP and TTL.

--- a/internal/dnsproxy/report_test.go
+++ b/internal/dnsproxy/report_test.go
@@ -26,8 +26,8 @@ func TestReportWaitDone(_ *testing.T) {
 	ttl := uint32(300)
 	r := NewReport(name, ip, ttl)
 
-	go r.Done()
-	r.Wait()
+	go r.Close()
+	<-r.Done()
 }
 
 // TestNewReport tests NewReport.

--- a/internal/splitrt/splitrt.go
+++ b/internal/splitrt/splitrt.go
@@ -202,7 +202,7 @@ func (s *SplitRouting) handleAddressUpdate(ctx context.Context, u *addrmon.Updat
 
 // handleDNSReport handles a DNS report.
 func (s *SplitRouting) handleDNSReport(ctx context.Context, r *dnsproxy.Report) {
-	defer r.Done()
+	defer r.Close()
 	log.WithField("report", r).Debug("SplitRouting handling DNS report")
 
 	if r.IP.To4() != nil {

--- a/internal/splitrt/splitrt_test.go
+++ b/internal/splitrt/splitrt_test.go
@@ -168,12 +168,12 @@ func TestSplitRoutingHandleDNSReport(t *testing.T) {
 	// test ipv4
 	report := dnsproxy.NewReport("example.com", net.ParseIP("192.168.1.1"), 300)
 	go s.handleDNSReport(ctx, report)
-	report.Wait()
+	<-report.Done()
 
 	// test ipv6
 	report = dnsproxy.NewReport("example.com", net.ParseIP("2001::1"), 300)
 	go s.handleDNSReport(ctx, report)
-	report.Wait()
+	<-report.Done()
 
 	want := []string{
 		"add element inet oc-daemon-routing excludes4 { 192.168.1.1/32 }",
@@ -259,7 +259,7 @@ func TestSplitRoutingStartStop(t *testing.T) {
 	s.addrmon.Updates() <- getTestAddrMonUpdate(t, "192.168.1.1/32")
 	report := dnsproxy.NewReport("example.com", net.ParseIP("192.168.1.1"), 300)
 	s.dnsreps <- report
-	report.Wait()
+	<-report.Done()
 	s.Stop()
 
 	// test with nft errors

--- a/internal/vpnsetup/vpnsetup.go
+++ b/internal/vpnsetup/vpnsetup.go
@@ -471,6 +471,8 @@ func (v *VPNSetup) handleDNSReport(r *dnsproxy.Report) {
 	log.WithField("report", r).Debug("Daemon handling DNS report")
 
 	if v.splitrt == nil {
+		// split routing not active, close report and do not forward
+		r.Close()
 		return
 	}
 

--- a/internal/vpnsetup/vpnsetup_test.go
+++ b/internal/vpnsetup/vpnsetup_test.go
@@ -363,7 +363,6 @@ func TestVPNSetupSetupTeardown(_ *testing.T) {
 
 	// send dns report while config is active
 	report := dnsproxy.NewReport("example.com", nil, 300)
-	go func() { report.Wait() }()
 	v.dnsProxy.Reports() <- report
 
 	// wait long enough for ensure timer

--- a/tools/dnsproxy/main.go
+++ b/tools/dnsproxy/main.go
@@ -81,6 +81,6 @@ func main() {
 	go p.Start()
 	for r := range p.Reports() {
 		log.WithField("report", r).Debug("DNS-Proxy got watched domain report")
-		r.Done()
+		r.Close()
 	}
 }


### PR DESCRIPTION
- Close reports when Split Routing is not active
- Stop waiting on reports when DNS Proxy is shutting down
- Close done channel in method Done() of Report
- Rename and rework Done() and Wait() methods of Report