### PR TITLE
internal/ocrunner: return when writing PID file fails

### DIFF
--- a/internal/ocrunner/connect.go
+++ b/internal/ocrunner/connect.go
@@ -137,6 +137,7 @@ func (c *Connect) savePidFile() {
 	err = osWriteFile(c.config.PIDFile, []byte(pid), os.FileMode(perm))
 	if err != nil {
 		log.WithError(err).Error("OC-Runner writing pid error")
+		return
 	}
 
 	// set owner and group


### PR DESCRIPTION
Return early when writing the PID file fails in the `savePidFile()` method of `Connect`.