### PR TITLE
Send vpncscript events to Daemon

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -342,12 +342,16 @@ func (d *Daemon) updateVPNConfig(request *api.Request) {
 		return
 	}
 
-	// handle config update for vpn (dis)connect
-	if configUpdate.Reason == "disconnect" {
+	// handle config update for vpn pre-init, connect, disconnect,
+	// attempt-reconnect, reconnect
+	log.WithField("reason", configUpdate.Reason).
+		Info("Daemon got OpenConnect event from VPNCScript")
+	switch configUpdate.Reason {
+	case "connect":
+		d.updateVPNConfigUp(configUpdate.Config)
+	case "disconnect":
 		d.updateVPNConfigDown()
-		return
 	}
-	d.updateVPNConfigUp(configUpdate.Config)
 }
 
 // handleClientRequest handles a client request.

--- a/internal/daemon/vpnconfigupdate.go
+++ b/internal/daemon/vpnconfigupdate.go
@@ -15,7 +15,7 @@ type VPNConfigUpdate struct {
 // Valid returns whether the config update is valid.
 func (c *VPNConfigUpdate) Valid() bool {
 	switch c.Reason {
-	case "disconnect":
+	case "pre-init", "disconnect", "attempt-reconnect", "reconnect":
 		// config must be nil
 		if c.Config != nil {
 			return false

--- a/internal/vpncscript/cmd.go
+++ b/internal/vpncscript/cmd.go
@@ -58,19 +58,13 @@ func run(args []string) error {
 
 	// handle reason environment variable
 	switch e.reason {
-	case "pre-init":
-		return nil
-	case "connect", "disconnect":
+	case "pre-init", "connect", "disconnect", "attempt-reconnect", "reconnect":
 		c, err := createConfigUpdate(e)
 		if err != nil {
 			return fmt.Errorf("VPNCScript could not create config update: %w", err)
 		}
 		log.WithField("update", c).Debug("VPNCScript created config update")
 		return runClient(socketFile, c)
-	case "attempt-reconnect":
-		return nil
-	case "reconnect":
-		return nil
 	default:
 		return errors.New("VPNCScript called with unknown reason")
 	}

--- a/internal/vpncscript/cmd_test.go
+++ b/internal/vpncscript/cmd_test.go
@@ -46,25 +46,16 @@ func TestRun(t *testing.T) {
 
 	// test with errors
 	for _, v := range []string{
+		"pre-init",
 		"connect",
 		"disconnect",
+		"attempt-reconnect",
+		"reconnect",
 		"invalid",
 	} {
 		t.Setenv("reason", v)
 		if err := run([]string{"test"}); err == nil {
 			t.Errorf("%s: should return error", v)
-		}
-	}
-
-	// test without errors
-	for _, v := range []string{
-		"pre-init",
-		"attempt-reconnect",
-		"reconnect",
-	} {
-		t.Setenv("reason", v)
-		if err := run([]string{"test"}); err != nil {
-			t.Errorf("%s: should not return error, got: %v", v, err)
 		}
 	}
 }


### PR DESCRIPTION
In addition to "connect" and "disconnect" events, also send the "pre-init", "attempt-reconnect" and "reconnect" events from vpncscript to the Daemon.