### PR TITLE
Ignore type when device was removed in devmon

### DIFF
--- a/internal/devmon/devmon.go
+++ b/internal/devmon/devmon.go
@@ -53,8 +53,11 @@ func (d *DevMon) handleLink(add bool, link netlink.Link) {
 		typ = "loopback"
 	}
 
-	// use special type for device that is actually virtual, e.g., vboxnet
-	if typ == "device" {
+	// use special type for device that is actually virtual, e.g., vboxnet.
+	// this check only works when device was added. when device was
+	// removed, the symlink does not exist anymore. thus, we cannot be sure
+	// device is really a "device" when it was removed.
+	if add && typ == "device" {
 		sysfs := filepath.Join("/sys/class/net", attrs.Name)
 		path, err := filepath.EvalSymlinks(sysfs)
 		if err != nil {

--- a/internal/trafpol/trafpol.go
+++ b/internal/trafpol/trafpol.go
@@ -30,13 +30,11 @@ type TrafPol struct {
 
 // handleDeviceUpdate handles a device update.
 func (t *TrafPol) handleDeviceUpdate(ctx context.Context, u *devmon.Update) {
-	// skip physical devices and only allow virtual devices
-	if u.Type == "device" {
-		return
-	}
-
 	// add or remove virtual device to/from allowed devices
-	if u.Add {
+	// skip adding physical devices and only allow adding virtual devices.
+	// we cannot be sure about the type when removing devices, so do not
+	// skip when removing devices.
+	if u.Add && u.Type != "device" {
 		t.allowDevs.Add(ctx, u.Device)
 		return
 	}


### PR DESCRIPTION
When a network device was removed, devmon cannot determine the type of the device with a symlink check, because the symlink does not exist anymore. Thus, remove the check in devmon and ignore the type in trafpol for device removal.