### PR TITLE
Avoid Socket API errors in vpncscript during Daemon shutdown

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -671,11 +671,12 @@ func (d *Daemon) start() {
 	defer d.stopTrafPol()
 	defer d.stopTND()
 	defer d.vpnsetup.Stop()
+	defer d.server.Stop()
 	defer d.handleRunnerDisconnect() // clean up vpn config
 	defer d.runner.Stop()
-	defer d.server.Stop()
 	defer d.dbus.Stop()
 	defer d.profmon.Stop()
+	defer d.server.Shutdown()
 
 	// run main loop
 	for {

--- a/internal/vpncscript/client.go
+++ b/internal/vpncscript/client.go
@@ -44,8 +44,12 @@ func runClient(socketFile string, configUpdate *daemon.VPNConfigUpdate) error {
 		log.WithField("reply", reply.Value).
 			Debug("VPNCScript received OK reply from Daemon")
 	case api.TypeError:
-		log.WithField("error", string(reply.Value)).
-			Error("VPNCScript received error reply from Daemon")
+		e := string(reply.Value)
+		if e == api.ServerShuttingDown {
+			// skip logging error when server is shutting down
+			return nil
+		}
+		log.WithField("error", e).Error("VPNCScript received error reply from Daemon")
 	}
 	return nil
 }

--- a/internal/vpncscript/client_test.go
+++ b/internal/vpncscript/client_test.go
@@ -29,6 +29,7 @@ func TestRunClient(t *testing.T) {
 	if err := runClient(sockfile, &daemon.VPNConfigUpdate{}); err != nil {
 		t.Fatal(err)
 	}
+	server.Shutdown()
 	server.Stop()
 
 	// with error reply
@@ -42,6 +43,18 @@ func TestRunClient(t *testing.T) {
 	if err := server.Start(); err != nil {
 		t.Fatal(err)
 	}
+	if err := runClient(sockfile, &daemon.VPNConfigUpdate{}); err != nil {
+		t.Fatal(err)
+	}
+	server.Shutdown()
+	server.Stop()
+
+	// with "shutting down" error reply
+	server = api.NewServer(config)
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	server.Shutdown()
 	if err := runClient(sockfile, &daemon.VPNConfigUpdate{}); err != nil {
 		t.Fatal(err)
 	}
@@ -86,5 +99,6 @@ func TestRunClient(t *testing.T) {
 			t.Errorf("length %d returned error: %v", length, err)
 		}
 	}
+	server.Shutdown()
 	server.Stop()
 }


### PR DESCRIPTION
In order to avoid connection errors in vpncscript during Daemon shutdown, stop the Socket API server later and answer client requests with a "server is shutting down" error message that is not logged as error by vpncscript.