### PR TITLE
Avoid network device errors when disconnecting from VPN

### DIFF
--- a/internal/ocrunner/connect.go
+++ b/internal/ocrunner/connect.go
@@ -9,6 +9,7 @@ import (
 	"os/user"
 	"strconv"
 	"strings"
+	"syscall"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/telekom-mms/oc-daemon/pkg/logininfo"
@@ -186,6 +187,10 @@ func (c *Connect) handleConnect(e *ConnectEvent) {
 	}
 	parameters = append(parameters, c.config.ExtraArgs...)
 	c.command = execCommand(c.config.OpenConnect, parameters...)
+
+	// run command in own process group so it is not canceled by interrupt
+	// signal sent to daemon
+	c.command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	// run command, pass login info to stdin
 	b := bytes.NewBufferString(e.login.Cookie)

--- a/internal/vpnsetup/vpnsetup_test.go
+++ b/internal/vpnsetup/vpnsetup_test.go
@@ -357,9 +357,8 @@ func TestVPNSetupSetupTeardown(_ *testing.T) {
 	v.Start()
 	vpnconf := vpnconfig.New()
 
-	// setup config and wait for setup event
+	// setup config
 	v.Setup(vpnconf)
-	<-v.Events()
 
 	// send dns report while config is active
 	report := dnsproxy.NewReport("example.com", nil, 300)
@@ -368,25 +367,14 @@ func TestVPNSetupSetupTeardown(_ *testing.T) {
 	// wait long enough for ensure timer
 	time.Sleep(time.Second * 2)
 
-	// teardown config, wait for teardown event
+	// teardown config
 	v.Teardown(vpnconf)
-	<-v.Events()
 
 	// send dns report while config is not active
 	v.dnsProxy.Reports() <- dnsproxy.NewReport("example.com", nil, 300)
 
 	// stop vpn setup
 	v.Stop()
-}
-
-// TestVPNSetupEvents tests Events of VPNSetup.
-func TestVPNSetupEvents(t *testing.T) {
-	v := NewVPNSetup(dnsproxy.NewConfig(), splitrt.NewConfig())
-	want := v.events
-	got := v.Events()
-	if got != want {
-		t.Errorf("got %p, want %p", got, want)
-	}
 }
 
 // TestNewVPNSetup tests NewVPNSetup.
@@ -399,7 +387,6 @@ func TestNewVPNSetup(t *testing.T) {
 		v.dnsProxyConf != dnsConfig ||
 		v.splitrtConf != splitrtConfig ||
 		v.cmds == nil ||
-		v.events == nil ||
 		v.done == nil ||
 		v.closed == nil {
 		t.Errorf("invalid vpn setup")


### PR DESCRIPTION
When disconnecting from the VPN, the openconnect subprocess terminates and removes the VPN network device. Currently, openconnect can terminate before all teardown methods in VPNSetup are run. The teardown commands that set the network device down or revert the systemd-resolved configuration for the device then fail, because the device does not exist anymore. To avoid such errors

- Wait for completion of the setup and teardown commands in VPNSetup, so vpnscript and the openconnect subprocess have to wait and do not terminate before teardown is complete.
- Disconnect from the VPN before stopping OCRunner when Daemon is shutting down, to ensure openconnect is still running during teardown.
- Run openconnect in own process group so it gets not canceled by the interrupt signal sent to trigger the Daemon shutdown.