### PR TITLE
Set KillMode=mixed in systemd service

### DIFF
--- a/init/oc-daemon.service
+++ b/init/oc-daemon.service
@@ -8,6 +8,7 @@ Type=dbus
 BusName=com.telekom_mms.oc_daemon.Daemon
 Restart=on-failure
 ExecStart=/usr/bin/oc-daemon
+KillMode=mixed
 KillSignal=SIGINT
 
 [Install]


### PR DESCRIPTION
Set KillMode=mixed in systemd service so that the openconnect subprocess is not terminated immediately by systemd when the OC-Daemon service gets shut down.