### PR TITLE
Add info logging to Daemon

### DIFF
--- a/internal/daemon/cmd.go
+++ b/internal/daemon/cmd.go
@@ -125,6 +125,7 @@ func run(args []string) error {
 	var err error
 	select {
 	case <-c:
+		log.Info("Daemon got interrupt signal")
 	case err = <-daemon.Errors():
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -459,6 +459,7 @@ func (d *Daemon) handleSleepMonEvent(sleep bool) {
 
 	// disconnect vpn on resume
 	if !sleep && d.status.OCRunning.Running() {
+		log.Info("Daemon resuming after sleep, disconnecting")
 		d.disconnectVPN()
 	}
 }
@@ -476,7 +477,7 @@ func readXMLProfile(xmlProfile string) *xmlprofile.Profile {
 
 // handleProfileUpdate handles a xml profile update.
 func (d *Daemon) handleProfileUpdate() error {
-	log.Debug("Daemon handling XML profile update")
+	log.Info("Daemon got XML profile update")
 	d.profile = readXMLProfile(d.config.OpenConnect.XMLProfile)
 	d.stopTND()
 	d.stopTrafPol()
@@ -673,6 +674,7 @@ func (d *Daemon) start() {
 	defer d.server.Shutdown()
 
 	// run main loop
+	log.Info("Daemon started")
 	for {
 		select {
 		case req := <-d.server.Requests():
@@ -702,6 +704,7 @@ func (d *Daemon) start() {
 			}
 
 		case <-d.done:
+			log.Info("Daemon stopping")
 			return
 		}
 	}


### PR DESCRIPTION
Add info logging to Daemon for the following events: started, stopping, interrupt signal, resume after sleep, XML profile update.