### PR TITLE
Parse Login Info from whole lines in Client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,11 +2,11 @@
 package client
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"sync"
 
 	"github.com/godbus/dbus/v5"
@@ -478,10 +478,11 @@ var authenticate = func(d *DBusClient) error {
 	// FINGERPRINT=469bb424ec8835944d30bc77c77e8fc1d8e23a42
 	// RESOLVE='vpnserver.example.com:10.0.0.1'
 	//
-	s := b.String()
 	login := &logininfo.LoginInfo{}
 	login.Server = config.VPNServer
-	for _, line := range strings.Fields(s) {
+	scanner := bufio.NewScanner(&b)
+	for scanner.Scan() {
+		line := scanner.Text()
 		login.ParseLine(line)
 	}
 	d.SetLogin(login)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -307,6 +307,21 @@ func TestDBusClientAuthenticate(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
+
+	// test cookie with spaces
+	want = &logininfo.LoginInfo{
+		Cookie: "Test cookie with spaces!",
+	}
+	execCommand = func(string, ...string) *exec.Cmd {
+		return exec.Command("echo", "COOKIE='Test cookie with spaces!'")
+	}
+	if err := client.Authenticate(); err != nil {
+		t.Errorf("authenticate returned error: %v", err)
+	}
+	got = client.GetLogin()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
 }
 
 // TestDBusClientConnect tests Connect of DBusClient.


### PR DESCRIPTION
The Client captures stdout into a buffer, splits it into lines with strings.Fields() and parses the Login Info in those lines. But Login Info values like the Cookie can contain white space characters which results in parsing incomplete lines. So, extract whole lines from the buffer with a bufio.Scanner and use them to parse the Login Info.