### PR TITLE
Feature/add trafpol status to dbus properties

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -186,6 +186,10 @@ func printStatus(status *vpnstatus.Status) error {
 	if !verbose {
 		return nil
 	}
+
+	fmt.Printf("TrafPol State:    %s\n", status.TrafPolState)
+	fmt.Printf("Allowed Hosts:    %s\n", status.AllowedHosts)
+
 	if status.VPNConfig == nil {
 		fmt.Printf("VPN Config:\n")
 	} else {

--- a/internal/dbusapi/service.go
+++ b/internal/dbusapi/service.go
@@ -31,6 +31,8 @@ const (
 	PropertyConnectedAt     = "ConnectedAt"
 	PropertyServers         = "Servers"
 	PropertyOCRunning       = "OCRunning"
+	PropertyTrafPolState    = "TrafPolState"
+	PropertyAllowedHosts    = "AllowedHosts"
 	PropertyVPNConfig       = "VPNConfig"
 )
 
@@ -85,6 +87,18 @@ const (
 	OCRunningUnknown uint32 = iota
 	OCRunningNotRunning
 	OCRunningRunning
+)
+
+// Property "TrafPol State" states.
+const (
+	TrafPolStateUnknown uint32 = iota
+	TrafPolStateInactive
+	TrafPolStateActive
+)
+
+// Property "Allowed Hosts" values.
+var (
+	AllowedHostsInvalid []string
 )
 
 // Property "VPNConfig" values.
@@ -234,6 +248,8 @@ func (s *Service) start() {
 		s.props.SetMust(Interface, PropertyConnectedAt, ConnectedAtInvalid)
 		s.props.SetMust(Interface, PropertyServers, ServersInvalid)
 		s.props.SetMust(Interface, PropertyOCRunning, OCRunningUnknown)
+		s.props.SetMust(Interface, PropertyTrafPolState, TrafPolStateUnknown)
+		s.props.SetMust(Interface, PropertyAllowedHosts, AllowedHostsInvalid)
 		s.props.SetMust(Interface, PropertyVPNConfig, VPNConfigInvalid)
 	}
 
@@ -340,6 +356,18 @@ func (s *Service) Start() error {
 			},
 			PropertyOCRunning: {
 				Value:    OCRunningUnknown,
+				Writable: false,
+				Emit:     prop.EmitTrue,
+				Callback: nil,
+			},
+			PropertyTrafPolState: {
+				Value:    TrafPolStateUnknown,
+				Writable: false,
+				Emit:     prop.EmitTrue,
+				Callback: nil,
+			},
+			PropertyAllowedHosts: {
+				Value:    AllowedHostsInvalid,
 				Writable: false,
 				Emit:     prop.EmitTrue,
 				Callback: nil,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -154,6 +154,10 @@ func updateStatusFromProperties(status *vpnstatus.Status, props map[string]dbus.
 				err = v.Store(&dest.Servers)
 			case dbusapi.PropertyOCRunning:
 				err = v.Store(&dest.OCRunning)
+			case dbusapi.PropertyTrafPolState:
+				err = v.Store(&dest.TrafPolState)
+			case dbusapi.PropertyAllowedHosts:
+				err = v.Store(&dest.AllowedHosts)
 			case dbusapi.PropertyVPNConfig:
 				s := dbusapi.VPNConfigInvalid
 				if err := v.Store(&s); err != nil {
@@ -270,6 +274,10 @@ func handlePropertiesChanged(s *dbus.Signal, status *vpnstatus.Status) *vpnstatu
 			status.Servers = dbusapi.ServersInvalid
 		case dbusapi.PropertyOCRunning:
 			status.OCRunning = vpnstatus.OCRunningUnknown
+		case dbusapi.PropertyTrafPolState:
+			status.TrafPolState = vpnstatus.TrafPolStateUnknown
+		case dbusapi.PropertyAllowedHosts:
+			status.AllowedHosts = dbusapi.AllowedHostsInvalid
 		case dbusapi.PropertyVPNConfig:
 			status.VPNConfig = nil
 		}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -99,6 +99,8 @@ func TestDBusClientQuery(t *testing.T) {
 			dbusapi.PropertyConnectedAt:     dbus.MakeVariant(dbusapi.ConnectedAtInvalid),
 			dbusapi.PropertyServers:         dbus.MakeVariant(dbusapi.ServersInvalid),
 			dbusapi.PropertyOCRunning:       dbus.MakeVariant(dbusapi.OCRunningUnknown),
+			dbusapi.PropertyTrafPolState:    dbus.MakeVariant(dbusapi.TrafPolStateUnknown),
+			dbusapi.PropertyAllowedHosts:    dbus.MakeVariant(dbusapi.AllowedHostsInvalid),
 			dbusapi.PropertyVPNConfig:       dbus.MakeVariant(dbusapi.VPNConfigInvalid),
 		},
 		{
@@ -210,6 +212,8 @@ func TestDBusClientSubscribe(t *testing.T) {
 				dbusapi.PropertyConnectedAt,
 				dbusapi.PropertyServers,
 				dbusapi.PropertyOCRunning,
+				dbusapi.PropertyTrafPolState,
+				dbusapi.PropertyAllowedHosts,
 				dbusapi.PropertyVPNConfig,
 			}},
 		},

--- a/pkg/vpnstatus/status.go
+++ b/pkg/vpnstatus/status.go
@@ -97,6 +97,29 @@ func (o OCRunning) String() string {
 	return ""
 }
 
+// TrafPolState is the current TrafPol state.
+type TrafPolState uint32
+
+// TrafPolState states.
+const (
+	TrafPolStateUnknown = iota
+	TrafPolStateInactive
+	TrafPolStateActive
+)
+
+// String resturns TrafPolState as string.
+func (t TrafPolState) String() string {
+	switch t {
+	case TrafPolStateUnknown:
+		return "unknown"
+	case TrafPolStateInactive:
+		return "inactive"
+	case TrafPolStateActive:
+		return "active"
+	}
+	return ""
+}
+
 // Status is a VPN status.
 type Status struct {
 	TrustedNetwork  TrustedNetwork
@@ -108,6 +131,8 @@ type Status struct {
 	ConnectedAt     int64
 	Servers         []string
 	OCRunning       OCRunning
+	TrafPolState    TrafPolState
+	AllowedHosts    []string
 	VPNConfig       *vpnconfig.Config
 }
 
@@ -126,6 +151,8 @@ func (s *Status) Copy() *Status {
 		ConnectedAt:     s.ConnectedAt,
 		Servers:         append(s.Servers[:0:0], s.Servers...),
 		OCRunning:       s.OCRunning,
+		TrafPolState:    s.TrafPolState,
+		AllowedHosts:    append(s.AllowedHosts[:0:0], s.AllowedHosts...),
 		VPNConfig:       s.VPNConfig.Copy(),
 	}
 }

--- a/pkg/vpnstatus/status_test.go
+++ b/pkg/vpnstatus/status_test.go
@@ -116,6 +116,23 @@ func TestOCRunningString(t *testing.T) {
 	}
 }
 
+// TestTrafPolStateString tests String of TrafPolState.
+func TestTrafPolStateString(t *testing.T) {
+	for v, s := range map[TrafPolState]string{
+		// valid
+		TrafPolStateUnknown:  "unknown",
+		TrafPolStateInactive: "inactive",
+		TrafPolStateActive:   "active",
+
+		// invalid
+		123456: "",
+	} {
+		if v.String() != s {
+			t.Errorf("got %s, want %s", v.String(), s)
+		}
+	}
+}
+
 // TestStatusCopy tests Copy of Status.
 func TestStatusCopy(t *testing.T) {
 	// test nil
@@ -136,6 +153,8 @@ func TestStatusCopy(t *testing.T) {
 			ConnectedAt:     1700000000,
 			Servers:         []string{"test server 1", "test server 2"},
 			OCRunning:       OCRunningRunning,
+			TrafPolState:    TrafPolStateActive,
+			AllowedHosts:    []string{"test.example.com"},
 			VPNConfig:       vpnconfig.New(),
 		},
 	} {

--- a/tools/dbusclient/main.go
+++ b/tools/dbusclient/main.go
@@ -39,6 +39,8 @@ func main() {
 	connectedAt := dbusapi.ConnectedAtInvalid
 	servers := dbusapi.ServersInvalid
 	ocRunning := dbusapi.OCRunningUnknown
+	trafPolState := dbusapi.TrafPolStateUnknown
+	allowedHosts := dbusapi.AllowedHostsInvalid
 	vpnConfig := dbusapi.VPNConfigInvalid
 
 	getProperty := func(name string, val any) {
@@ -57,6 +59,8 @@ func main() {
 	getProperty(dbusapi.PropertyConnectedAt, &connectedAt)
 	getProperty(dbusapi.PropertyServers, &servers)
 	getProperty(dbusapi.PropertyOCRunning, &ocRunning)
+	getProperty(dbusapi.PropertyTrafPolState, &trafPolState)
+	getProperty(dbusapi.PropertyAllowedHosts, &allowedHosts)
 	getProperty(dbusapi.PropertyVPNConfig, &vpnConfig)
 
 	log.Println("TrustedNetwork:", trustedNetwork)
@@ -68,6 +72,8 @@ func main() {
 	log.Println("ConnectedAt:", connectedAt)
 	log.Println("Servers:", servers)
 	log.Println("OCRunning:", ocRunning)
+	log.Println("TrafPolState:", trafPolState)
+	log.Println("AllowedHosts:", allowedHosts)
 	log.Println("VPNConfig:", vpnConfig)
 
 	// handle signals
@@ -141,6 +147,16 @@ func main() {
 					log.Fatal(err)
 				}
 				fmt.Println(ocRunning)
+			case dbusapi.PropertyTrafPolState:
+				if err := value.Store(&trafPolState); err != nil {
+					log.Fatal(err)
+				}
+				fmt.Println(trafPolState)
+			case dbusapi.PropertyAllowedHosts:
+				if err := value.Store(&allowedHosts); err != nil {
+					log.Fatal(err)
+				}
+				fmt.Println(allowedHosts)
 			case dbusapi.PropertyVPNConfig:
 				if err := value.Store(&vpnConfig); err != nil {
 					log.Fatal(err)
@@ -176,6 +192,10 @@ func main() {
 				servers = dbusapi.ServersInvalid
 			case dbusapi.PropertyOCRunning:
 				ocRunning = dbusapi.OCRunningUnknown
+			case dbusapi.PropertyTrafPolState:
+				trafPolState = dbusapi.TrafPolStateUnknown
+			case dbusapi.PropertyAllowedHosts:
+				allowedHosts = dbusapi.AllowedHostsInvalid
 			case dbusapi.PropertyVPNConfig:
 				vpnConfig = dbusapi.VPNConfigInvalid
 			}


### PR DESCRIPTION
- Add TrafPol State to D-Bus Properties
- Add Allowed Hosts to D-Bus Properties
- Start D-Bus API before TrafPol so we can change the D-Bus Properties of TrafPol at startup