### PR TITLE
Switch to package netip internally

### DIFF
--- a/internal/addrmon/addrmon_test.go
+++ b/internal/addrmon/addrmon_test.go
@@ -2,6 +2,7 @@ package addrmon
 
 import (
 	"log"
+	"net"
 	"testing"
 
 	"github.com/vishvananda/netlink"
@@ -44,7 +45,12 @@ func TestAddrMonStartStop(t *testing.T) {
 	// helper function for AddrUpdates
 	addrUpdates := func(updates chan netlink.AddrUpdate, done chan struct{}) {
 		for {
-			up := netlink.AddrUpdate{}
+			up := netlink.AddrUpdate{
+				LinkAddress: net.IPNet{
+					IP:   net.IPv4(192, 168, 1, 1),
+					Mask: net.CIDRMask(24, 32),
+				},
+			}
 			select {
 			case updates <- up:
 			case <-done:

--- a/internal/dnsproxy/proxy.go
+++ b/internal/dnsproxy/proxy.go
@@ -3,6 +3,7 @@ package dnsproxy
 
 import (
 	"math/rand"
+	"net/netip"
 
 	"github.com/miekg/dns"
 	log "github.com/sirupsen/logrus"
@@ -101,7 +102,13 @@ func (p *Proxy) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 			log.Error("DNS-Proxy received invalid A record in reply")
 			return
 		}
-		report := NewReport(rr.Hdr.Name, rr.A, rr.Hdr.Ttl)
+		addr, ok := netip.AddrFromSlice(rr.A)
+		if !ok {
+			log.WithField("A", rr.A).
+				Error("DNS-Proxy received invalid IP in A record in reply")
+			return
+		}
+		report := NewReport(rr.Hdr.Name, addr, rr.Hdr.Ttl)
 		p.sendReport(report)
 		p.waitReport(report)
 	}
@@ -114,7 +121,13 @@ func (p *Proxy) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 			log.Error("DNS-Proxy received invalid AAAA record in reply")
 			return
 		}
-		report := NewReport(rr.Hdr.Name, rr.AAAA, rr.Hdr.Ttl)
+		addr, ok := netip.AddrFromSlice(rr.AAAA)
+		if !ok {
+			log.WithField("AAAA", rr.AAAA).
+				Error("DNS-Proxy received invalid IP in AAAA record in reply")
+			return
+		}
+		report := NewReport(rr.Hdr.Name, addr, rr.Hdr.Ttl)
 		p.sendReport(report)
 		p.waitReport(report)
 	}

--- a/internal/dnsproxy/proxy_test.go
+++ b/internal/dnsproxy/proxy_test.go
@@ -3,6 +3,7 @@ package dnsproxy
 import (
 	"errors"
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -127,8 +128,8 @@ func TestProxyHandleRequest(t *testing.T) {
 		if r.Name != "example.com." {
 			t.Errorf("invalid domain name: %s", r.Name)
 		}
-		if !r.IP.Equal(net.IPv4(127, 0, 0, 1)) &&
-			!r.IP.Equal(net.ParseIP("::1")) {
+		if r.IP != netip.MustParseAddr("127.0.0.1") &&
+			r.IP != netip.MustParseAddr("::1") {
 			t.Errorf("invalid IP: %s", r.IP)
 		}
 	}
@@ -205,8 +206,8 @@ func TestProxyHandleRequestRecords(t *testing.T) {
 			t.Fatalf("invalid reports for run %d: %v", i, reports)
 		}
 		for _, r := range reports {
-			if !r.IP.Equal(net.ParseIP("127.0.0.1")) &&
-				!r.IP.Equal(net.ParseIP("::1")) {
+			if r.IP != netip.MustParseAddr("127.0.0.1") &&
+				r.IP != netip.MustParseAddr("::1") {
 
 				t.Errorf("invalid report for run %d: %v", i, r)
 			}

--- a/internal/dnsproxy/report.go
+++ b/internal/dnsproxy/report.go
@@ -2,13 +2,13 @@ package dnsproxy
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 )
 
 // Report is a report for a watched domain.
 type Report struct {
 	Name string
-	IP   net.IP
+	IP   netip.Addr
 	TTL  uint32
 
 	// done is used to signal that the report has been handled by
@@ -32,7 +32,7 @@ func (r *Report) Done() <-chan struct{} {
 }
 
 // NewReport returns a new report with domain name, IP and TTL.
-func NewReport(name string, ip net.IP, ttl uint32) *Report {
+func NewReport(name string, ip netip.Addr, ttl uint32) *Report {
 	return &Report{
 		Name: name,
 		IP:   ip,

--- a/internal/dnsproxy/report_test.go
+++ b/internal/dnsproxy/report_test.go
@@ -1,14 +1,14 @@
 package dnsproxy
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 )
 
 // TestReportString tests String of Report.
 func TestReportString(t *testing.T) {
 	name := "example.com."
-	ip := net.IPv4(192, 168, 1, 1)
+	ip := netip.MustParseAddr("192.168.1.1")
 	ttl := uint32(300)
 	r := NewReport(name, ip, ttl)
 
@@ -22,7 +22,7 @@ func TestReportString(t *testing.T) {
 // TestReportDone tests Wait and Done of Report.
 func TestReportWaitDone(_ *testing.T) {
 	name := "example.com."
-	ip := net.IPv4(192, 168, 1, 1)
+	ip := netip.MustParseAddr("192.168.1.1")
 	ttl := uint32(300)
 	r := NewReport(name, ip, ttl)
 
@@ -33,7 +33,7 @@ func TestReportWaitDone(_ *testing.T) {
 // TestNewReport tests NewReport.
 func TestNewReport(t *testing.T) {
 	name := "example.com."
-	ip := net.IPv4(192, 168, 1, 1)
+	ip := netip.MustParseAddr("192.168.1.1")
 	ttl := uint32(300)
 	r := NewReport(name, ip, ttl)
 
@@ -43,7 +43,7 @@ func TestNewReport(t *testing.T) {
 	if r.Name != name {
 		t.Errorf("got %s, want %s", r.Name, name)
 	}
-	if !r.IP.Equal(ip) {
+	if r.IP != ip {
 		t.Errorf("got %s, want %s", r.IP, ip)
 	}
 	if r.TTL != ttl {

--- a/internal/splitrt/addresses.go
+++ b/internal/splitrt/addresses.go
@@ -1,7 +1,7 @@
 package splitrt
 
 import (
-	"net"
+	"net/netip"
 
 	"github.com/telekom-mms/oc-daemon/internal/addrmon"
 )
@@ -51,9 +51,9 @@ func (a *Addresses) Remove(addr *addrmon.Update) {
 }
 
 // Get returns the addresses of the device identified by index.
-func (a *Addresses) Get(index int) (addrs []*net.IPNet) {
+func (a *Addresses) Get(index int) (addrs []netip.Prefix) {
 	for _, x := range a.m[index] {
-		addrs = append(addrs, &x.Address)
+		addrs = append(addrs, x.Address)
 	}
 	return
 }

--- a/internal/splitrt/addresses_test.go
+++ b/internal/splitrt/addresses_test.go
@@ -1,7 +1,7 @@
 package splitrt
 
 import (
-	"net"
+	"net/netip"
 	"reflect"
 	"testing"
 
@@ -10,14 +10,14 @@ import (
 
 // getTestAddrMonUpdate returns an AddrMon update for testing.
 func getTestAddrMonUpdate(t *testing.T, addr string) *addrmon.Update {
-	_, ipnet, err := net.ParseCIDR(addr)
+	prefix, err := netip.ParsePrefix(addr)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	return &addrmon.Update{
 		Add:     true,
-		Address: *ipnet,
+		Address: prefix,
 		Index:   1,
 	}
 }
@@ -72,7 +72,7 @@ func TestAddressesGet(t *testing.T) {
 	update2 := getTestAddrMonUpdate(t, "192.168.2.0/24")
 
 	// get empty
-	var want []*net.IPNet
+	var want []netip.Prefix
 	got := a.Get(1)
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)
@@ -80,8 +80,8 @@ func TestAddressesGet(t *testing.T) {
 
 	// get with one address
 	a.Add(update1)
-	want = []*net.IPNet{
-		&update1.Address,
+	want = []netip.Prefix{
+		update1.Address,
 	}
 	got = a.Get(1)
 	if !reflect.DeepEqual(got, want) {
@@ -97,9 +97,9 @@ func TestAddressesGet(t *testing.T) {
 
 	// get with multiple addresses
 	a.Add(update2)
-	want = []*net.IPNet{
-		&update1.Address,
-		&update2.Address,
+	want = []netip.Prefix{
+		update1.Address,
+		update2.Address,
 	}
 	got = a.Get(1)
 	if !reflect.DeepEqual(got, want) {

--- a/internal/splitrt/excludes_test.go
+++ b/internal/splitrt/excludes_test.go
@@ -3,7 +3,7 @@ package splitrt
 import (
 	"context"
 	"errors"
-	"net"
+	"net/netip"
 	"reflect"
 	"testing"
 
@@ -11,10 +11,10 @@ import (
 )
 
 // getTestExcludes returns excludes for testing.
-func getTestExcludes(t *testing.T, es []string) []*net.IPNet {
-	excludes := []*net.IPNet{}
+func getTestExcludes(t *testing.T, es []string) []netip.Prefix {
+	excludes := []netip.Prefix{}
 	for _, s := range es {
-		_, exclude, err := net.ParseCIDR(s)
+		exclude, err := netip.ParsePrefix(s)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -24,7 +24,7 @@ func getTestExcludes(t *testing.T, es []string) []*net.IPNet {
 }
 
 // getTestStaticExcludes returns static excludes for testing.
-func getTestStaticExcludes(t *testing.T) []*net.IPNet {
+func getTestStaticExcludes(t *testing.T) []netip.Prefix {
 	return getTestExcludes(t, []string{
 		"192.168.1.0/24",
 		"2001::/64",
@@ -32,7 +32,7 @@ func getTestStaticExcludes(t *testing.T) []*net.IPNet {
 }
 
 // getTestStaticExcludesOverlap returns static excludes that overlap for testing.
-func getTestStaticExcludesOverlap(t *testing.T) []*net.IPNet {
+func getTestStaticExcludesOverlap(t *testing.T) []netip.Prefix {
 	return getTestExcludes(t, []string{
 		"192.168.1.0/26",
 		"192.168.1.64/26",
@@ -52,7 +52,7 @@ func getTestStaticExcludesOverlap(t *testing.T) []*net.IPNet {
 }
 
 // getTestDynamicExcludes returns dynamic excludes for testing.
-func getTestDynamicExcludes(t *testing.T) []*net.IPNet {
+func getTestDynamicExcludes(t *testing.T) []netip.Prefix {
 	return getTestExcludes(t, []string{
 		"192.168.1.1/32",
 		"2001::1/128",

--- a/internal/splitrt/splitrt_test.go
+++ b/internal/splitrt/splitrt_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/netip"
 	"reflect"
 	"strings"
 	"testing"
@@ -166,12 +167,12 @@ func TestSplitRoutingHandleDNSReport(t *testing.T) {
 	defer func() { execs.RunCmd = oldRunCmd }()
 
 	// test ipv4
-	report := dnsproxy.NewReport("example.com", net.ParseIP("192.168.1.1"), 300)
+	report := dnsproxy.NewReport("example.com", netip.MustParseAddr("192.168.1.1"), 300)
 	go s.handleDNSReport(ctx, report)
 	<-report.Done()
 
 	// test ipv6
-	report = dnsproxy.NewReport("example.com", net.ParseIP("2001::1"), 300)
+	report = dnsproxy.NewReport("example.com", netip.MustParseAddr("2001::1"), 300)
 	go s.handleDNSReport(ctx, report)
 	<-report.Done()
 
@@ -257,7 +258,7 @@ func TestSplitRoutingStartStop(t *testing.T) {
 	}
 	s.devmon.Updates() <- getTestDevMonUpdate()
 	s.addrmon.Updates() <- getTestAddrMonUpdate(t, "192.168.1.1/32")
-	report := dnsproxy.NewReport("example.com", net.ParseIP("192.168.1.1"), 300)
+	report := dnsproxy.NewReport("example.com", netip.MustParseAddr("192.168.1.1"), 300)
 	s.dnsreps <- report
 	<-report.Done()
 	s.Stop()

--- a/internal/trafpol/filter.go
+++ b/internal/trafpol/filter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 
@@ -206,7 +206,7 @@ func removeAllowedDevice(ctx context.Context, device string) {
 }
 
 // setAllowedIPs set the allowed hosts.
-func setAllowedIPs(ctx context.Context, ips []*net.IPNet) {
+func setAllowedIPs(ctx context.Context, ips []netip.Prefix) {
 	// we perform all nft commands separately here and not as one atomic
 	// operation to avoid issues where the whole update fails because nft
 	// runs into "file exists" errors even though we remove duplicates from
@@ -234,7 +234,7 @@ func setAllowedIPs(ctx context.Context, ips []*net.IPNet) {
 	fmt4 := "add element inet oc-daemon-filter allowhosts4 { %s }"
 	fmt6 := "add element inet oc-daemon-filter allowhosts6 { %s }"
 	for _, ip := range ips {
-		if ip.IP.To4() != nil {
+		if ip.Addr().Is4() {
 			// ipv4 address
 			nftconf := fmt.Sprintf(fmt4, ip)
 			if stdout, stderr, err := execs.RunNft(ctx, nftconf); err != nil &&

--- a/internal/trafpol/filter_test.go
+++ b/internal/trafpol/filter_test.go
@@ -3,7 +3,7 @@ package trafpol
 import (
 	"context"
 	"errors"
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/telekom-mms/oc-daemon/internal/execs"
@@ -28,9 +28,9 @@ func TestFilterFunctionsErrors(_ *testing.T) {
 	removeAllowedDevice(ctx, "eth0")
 
 	// allowed IPs
-	setAllowedIPs(ctx, []*net.IPNet{
-		{IP: net.ParseIP("192.168.1.1"), Mask: net.CIDRMask(32, 32)},
-		{IP: net.ParseIP("2000::1"), Mask: net.CIDRMask(128, 128)},
+	setAllowedIPs(ctx, []netip.Prefix{
+		netip.MustParsePrefix("192.168.1.1/32"),
+		netip.MustParsePrefix("2000::1/128"),
 	})
 
 	// portal ports

--- a/internal/trafpol/resolver.go
+++ b/internal/trafpol/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/netip"
 	"sort"
 	"sync"
 	"time"
@@ -12,7 +13,7 @@ import (
 // ResolvedName is a resolved DNS name.
 type ResolvedName struct {
 	Name string
-	IPs  []net.IP
+	IPs  []netip.Addr
 	TTL  time.Duration
 }
 
@@ -48,8 +49,8 @@ func (r *ResolvedName) resolve(ctx context.Context, config *Config, updates chan
 		// lookup IPv4 and IPv6 addresses in one call (argument
 		// network == "ip"). So, resolve IPv4 and IPv6 addresses in
 		// separate calls
-		ipv4s, err4 := resolver.LookupIP(ctxTO, "ip4", r.Name)
-		ipv6s, err6 := resolver.LookupIP(ctxTO, "ip6", r.Name)
+		ipv4s, err4 := resolver.LookupNetIP(ctxTO, "ip4", r.Name)
+		ipv6s, err6 := resolver.LookupNetIP(ctxTO, "ip6", r.Name)
 		if err4 != nil && err6 != nil {
 			// do not retry hostnames that are not found
 			var dnsErr4 *net.DNSError
@@ -79,7 +80,7 @@ func (r *ResolvedName) resolve(ctx context.Context, config *Config, updates chan
 				return false
 			}
 			for i := range r.IPs {
-				if !r.IPs[i].Equal(ips[i]) {
+				if r.IPs[i] != ips[i] {
 					return false
 				}
 			}

--- a/internal/trafpol/resolver_test.go
+++ b/internal/trafpol/resolver_test.go
@@ -1,7 +1,7 @@
 package trafpol
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 	"time"
 )
@@ -45,7 +45,7 @@ func TestResolverResolve(_ *testing.T) {
 		names = []string{"example.com"}
 		r = NewResolver(config, names, updates)
 		r.names["example.com"] = u
-		r.names["example.com"].IPs[0] = net.ParseIP("127.0.0.1")
+		r.names["example.com"].IPs[0] = netip.MustParseAddr("127.0.0.1")
 
 		r.Start()
 

--- a/internal/vpnsetup/vpnsetup_test.go
+++ b/internal/vpnsetup/vpnsetup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/netip"
 	"reflect"
 	"strings"
 	"testing"
@@ -361,7 +362,7 @@ func TestVPNSetupSetupTeardown(_ *testing.T) {
 	v.Setup(vpnconf)
 
 	// send dns report while config is active
-	report := dnsproxy.NewReport("example.com", nil, 300)
+	report := dnsproxy.NewReport("example.com", netip.Addr{}, 300)
 	v.dnsProxy.Reports() <- report
 
 	// wait long enough for ensure timer
@@ -371,7 +372,7 @@ func TestVPNSetupSetupTeardown(_ *testing.T) {
 	v.Teardown(vpnconf)
 
 	// send dns report while config is not active
-	v.dnsProxy.Reports() <- dnsproxy.NewReport("example.com", nil, 300)
+	v.dnsProxy.Reports() <- dnsproxy.NewReport("example.com", netip.Addr{}, 300)
 
 	// stop vpn setup
 	v.Stop()


### PR DESCRIPTION
Switch from using the types net.IP, net.IPNet and net.IPMask to netip.Addr and netip.Prefix internally.