### PR TITLE
Specify exact minimum Go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/telekom-mms/oc-daemon
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/fsnotify/fsnotify v1.7.0


### PR DESCRIPTION
Starting with Go version 1.21, the exact minimum Go release version or the toolchain version must be specified in go.mod (see also https://github.com/golang/go/issues/62278#issuecomment-1693538776). So, change the Go version from "1.23" to "1.23.0".