### PR TITLE
Remove nftables updates from AllowDevs

### DIFF
--- a/internal/trafpol/allowdevs.go
+++ b/internal/trafpol/allowdevs.go
@@ -1,26 +1,26 @@
 package trafpol
 
-import "context"
-
 // AllowDevs contains allowed devices.
 type AllowDevs struct {
 	m map[string]string
 }
 
 // Add adds device to the allowed devices.
-func (a *AllowDevs) Add(ctx context.Context, device string) {
+func (a *AllowDevs) Add(device string) bool {
 	if a.m[device] != device {
 		a.m[device] = device
-		addAllowedDevice(ctx, device)
+		return true
 	}
+	return false
 }
 
 // Remove removes device from the allowed devices.
-func (a *AllowDevs) Remove(ctx context.Context, device string) {
+func (a *AllowDevs) Remove(device string) bool {
 	if a.m[device] == device {
 		delete(a.m, device)
-		removeAllowedDevice(ctx, device)
+		return true
 	}
+	return false
 }
 
 // List returns a slice of all allowed devices.

--- a/internal/trafpol/allowdevs_test.go
+++ b/internal/trafpol/allowdevs_test.go
@@ -1,88 +1,47 @@
 package trafpol
 
 import (
-	"context"
-	"reflect"
 	"slices"
 	"testing"
-
-	"github.com/telekom-mms/oc-daemon/internal/execs"
 )
 
 // TestAllowDevsAdd tests Add of AllowDevs.
 func TestAllowDevsAdd(t *testing.T) {
 	a := NewAllowDevs()
-	ctx := context.Background()
-
-	got := []string{}
-	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
-		got = append(got, s)
-		return nil, nil, nil
-	}
-	defer func() { execs.RunCmd = oldRunCmd }()
 
 	// test adding
-	want := []string{
-		"add element inet oc-daemon-filter allowdevs { eth3 }",
-	}
-	a.Add(ctx, "eth3")
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	if !a.Add("eth3") {
+		t.Error("device should be added")
 	}
 
 	// test adding again
 	// should not change anything
-	a.Add(ctx, "eth3")
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	if a.Add("eth3") {
+		t.Error("device should not be added again")
 	}
 }
 
 // TestAllowDevsRemove tests Remove of AllowDevs.
 func TestAllowDevsRemove(t *testing.T) {
 	a := NewAllowDevs()
-	ctx := context.Background()
-
-	got := []string{}
-	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(_ context.Context, _ string, s string, _ ...string) ([]byte, []byte, error) {
-		got = append(got, s)
-		return nil, nil, nil
-	}
-	defer func() { execs.RunCmd = oldRunCmd }()
 
 	// test removing device
-	a.Add(ctx, "eth3")
-	want := []string{
-		"delete element inet oc-daemon-filter allowdevs { eth3 }",
-	}
-	got = []string{}
-	a.Remove(ctx, "eth3")
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	a.Add("eth3")
+	if !a.Remove("eth3") {
+		t.Error("device should be removed")
 	}
 
 	// test removing again (not existing device)
 	// should not change anything
-	a.Remove(ctx, "eth3")
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
+	if a.Remove("eth3") {
+		t.Error("not existing device should not be removed")
 	}
 }
 
 // TestAllowDevsList tests List of AllowDevs.
 func TestAllowDevsList(t *testing.T) {
 	a := NewAllowDevs()
-	ctx := context.Background()
-
-	oldRunCmd := execs.RunCmd
-	execs.RunCmd = func(_ context.Context, _, _ string, _ ...string) ([]byte, []byte, error) {
-		return nil, nil, nil
-	}
-	defer func() { execs.RunCmd = oldRunCmd }()
-
-	a.Add(ctx, "test")
+	a.Add("test")
 
 	want := []string{"test"}
 	got := a.List()

--- a/internal/trafpol/trafpol.go
+++ b/internal/trafpol/trafpol.go
@@ -70,10 +70,14 @@ func (t *TrafPol) handleDeviceUpdate(ctx context.Context, u *devmon.Update) {
 	// we cannot be sure about the type when removing devices, so do not
 	// skip when removing devices.
 	if u.Add && u.Type != "device" {
-		t.allowDevs.Add(ctx, u.Device)
+		if t.allowDevs.Add(u.Device) {
+			addAllowedDevice(ctx, u.Device)
+		}
 		return
 	}
-	t.allowDevs.Remove(ctx, u.Device)
+	if t.allowDevs.Remove(u.Device) {
+		removeAllowedDevice(ctx, u.Device)
+	}
 }
 
 // handleDNSUpdate handles a dns config update.

--- a/internal/trafpol/trafpol_test.go
+++ b/internal/trafpol/trafpol_test.go
@@ -23,7 +23,8 @@ func TestTrafPolHandleDeviceUpdate(_ *testing.T) {
 
 	// test adding
 	update := &devmon.Update{
-		Add: true,
+		Device: "test0",
+		Add:    true,
 	}
 	tp.handleDeviceUpdate(ctx, update)
 


### PR DESCRIPTION
Remove nftables updates from AllowDevs methods. Instead, return whether device was added/removed and let caller update nftables.