### PR TITLE
Remove addExclude() from Split Routing

### DIFF
--- a/internal/splitrt/filter.go
+++ b/internal/splitrt/filter.go
@@ -195,26 +195,6 @@ func rejectIPv4(ctx context.Context, device string) {
 	rejectIPVersion(ctx, device, "ipv4")
 }
 
-// addExclude adds exclude address to netfilter.
-func addExclude(ctx context.Context, address netip.Prefix) {
-	log.WithField("address", address).Debug("SplitRouting adding exclude to netfilter")
-
-	set := "excludes4"
-	if address.Addr().Is6() {
-		set = "excludes6"
-	}
-
-	nftconf := fmt.Sprintf("add element inet oc-daemon-routing %s { %s }",
-		set, address)
-	if stdout, stderr, err := execs.RunNft(ctx, nftconf); err != nil {
-		log.WithError(err).WithFields(log.Fields{
-			"address": address,
-			"stdout":  string(stdout),
-			"stderr":  string(stderr),
-		}).Error("SplitRouting error adding exclude")
-	}
-}
-
 // setExcludes resets the excludes to addresses in netfilter.
 func setExcludes(ctx context.Context, addresses []netip.Prefix) {
 	// flush existing entries

--- a/internal/splitrt/splitrt.go
+++ b/internal/splitrt/splitrt.go
@@ -245,7 +245,7 @@ func (s *SplitRouting) handleDNSReport(ctx context.Context, r *dnsproxy.Report) 
 
 	exclude := netip.PrefixFrom(r.IP, r.IP.BitLen())
 	if s.excludes.AddDynamic(exclude, r.TTL) {
-		addExclude(ctx, exclude)
+		setExcludes(ctx, s.excludes.GetPrefixes())
 	}
 }
 

--- a/internal/splitrt/splitrt_test.go
+++ b/internal/splitrt/splitrt_test.go
@@ -174,8 +174,13 @@ func TestSplitRoutingHandleDNSReport(t *testing.T) {
 	<-report.Done()
 
 	want := []string{
-		"add element inet oc-daemon-routing excludes4 { 192.168.1.1/32 }",
-		"add element inet oc-daemon-routing excludes6 { 2001::1/128 }",
+		"flush set inet oc-daemon-routing excludes4\n" +
+			"flush set inet oc-daemon-routing excludes6\n" +
+			"add element inet oc-daemon-routing excludes4 { 192.168.1.1/32 }\n",
+		"flush set inet oc-daemon-routing excludes4\n" +
+			"flush set inet oc-daemon-routing excludes6\n" +
+			"add element inet oc-daemon-routing excludes4 { 192.168.1.1/32 }\n" +
+			"add element inet oc-daemon-routing excludes6 { 2001::1/128 }\n",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v", got, want)


### PR DESCRIPTION
Simplify Split Routing: remove addExclude() and only use setExcludes().