### PR TITLE
Add commands for setting allowed ports to TrafPol

### DIFF
--- a/internal/cmdtmpl/command.go
+++ b/internal/cmdtmpl/command.go
@@ -252,21 +252,16 @@ add element inet oc-daemon-filter allowdevs { {{.}} }
 			},
 			defaultTemplate: TrafPolDefaultTemplate,
 		}
-	case "TrafPolAddPortalPorts":
+	case "TrafPolSetAllowedPorts":
 		// Remove Portal Ports
 		cl = &CommandList{
 			Name: name,
 			Commands: []*Command{
-				{Line: "{{.Executables.Nft}} -f - add element inet oc-daemon-filter allowports { {{range $i, $port := .TrafficPolicing.PortalPorts}}{{if $i}}, {{end}}{{$port}}{{end}} }"},
-			},
-			defaultTemplate: TrafPolDefaultTemplate,
-		}
-	case "TrafPolRemovePortalPorts":
-		// Remove Portal Ports
-		cl = &CommandList{
-			Name: name,
-			Commands: []*Command{
-				{Line: "{{.Executables.Nft}} -f - delete element inet oc-daemon-filter allowports { {{range $i, $port := .TrafficPolicing.PortalPorts}}{{if $i}}, {{end}}{{$port}}{{end}} }"},
+				{Line: "{{.Executables.Nft}} -f -",
+					Stdin: `flush set inet oc-daemon-filter allowports
+{{range .Ports -}}
+add element inet oc-daemon-filter allowports { {{.}} }
+{{end}}`},
 			},
 			defaultTemplate: TrafPolDefaultTemplate,
 		}

--- a/internal/cmdtmpl/command_test.go
+++ b/internal/cmdtmpl/command_test.go
@@ -40,8 +40,7 @@ func TestGetCommandList(t *testing.T) {
 		"TrafPolSetAllowedDevices",
 		"TrafPolFlushAllowedHosts",
 		"TrafPolAddAllowedHost",
-		"TrafPolAddPortalPorts",
-		"TrafPolRemovePortalPorts",
+		"TrafPolSetAllowedPorts",
 		"TrafPolCleanup",
 
 		// VPN Setup
@@ -91,8 +90,7 @@ func TestGetCmds(t *testing.T) {
 		// TrafPolSetAllowedDevices", // skip, requires devices
 		"TrafPolFlushAllowedHosts",
 		// "TrafPolAddAllowedHost", // skip, requires host
-		"TrafPolAddPortalPorts",
-		"TrafPolRemovePortalPorts",
+		//"TrafPolSetAllowedPorts", // skip, requires ports
 		"TrafPolCleanup",
 
 		// VPN Setup
@@ -117,6 +115,7 @@ func TestGetCmds(t *testing.T) {
 		// Traffic Policing
 		"TrafPolSetAllowedDevices",
 		"TrafPolAddAllowedHost",
+		"TrafPolSetAllowedPorts",
 
 		// VPN Setup
 		"VPNSetupSetExcludes",

--- a/internal/trafpol/filter.go
+++ b/internal/trafpol/filter.go
@@ -132,44 +132,30 @@ func setAllowedIPs(ctx context.Context, conf *daemoncfg.Config, ips []netip.Pref
 	}
 }
 
-// addPortalPorts adds ports for a captive portal to the allowed ports.
-func addPortalPorts(ctx context.Context, conf *daemoncfg.Config) {
-	cmds, err := cmdtmpl.GetCmds("TrafPolAddPortalPorts", conf)
+// setAllowedPorts sets ports (for a captive portal) as the allowed ports.
+func setAllowedPorts(ctx context.Context, conf *daemoncfg.Config, ports []uint16) {
+	data := &struct {
+		daemoncfg.Config
+		Ports []uint16
+	}{
+		Config: *conf,
+		Ports:  ports,
+	}
+	cmds, err := cmdtmpl.GetCmds("TrafPolSetAllowedPorts", data)
 	if err != nil {
-		log.WithError(err).Error("TrafPol could not get add portal ports commands")
+		log.WithError(err).Error("TrafPol could not get set allowed ports commands")
 	}
 	for _, c := range cmds {
 		if stdout, stderr, err := c.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			log.WithFields(log.Fields{
-				"ports":   conf.TrafficPolicing.PortalPorts,
+				"ports":   ports,
 				"command": c.Cmd,
 				"args":    c.Args,
 				"stdin":   c.Stdin,
 				"stdout":  string(stdout),
 				"stderr":  string(stderr),
 				"error":   err,
-			}).Error("TrafPol could not run add portal ports command")
-		}
-	}
-}
-
-// removePortalPorts removes ports for a captive portal from the allowed ports.
-func removePortalPorts(ctx context.Context, conf *daemoncfg.Config) {
-	cmds, err := cmdtmpl.GetCmds("TrafPolRemovePortalPorts", conf)
-	if err != nil {
-		log.WithError(err).Error("TrafPol could not get remove portal ports commands")
-	}
-	for _, c := range cmds {
-		if stdout, stderr, err := c.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			log.WithFields(log.Fields{
-				"ports":   conf.TrafficPolicing.PortalPorts,
-				"command": c.Cmd,
-				"args":    c.Args,
-				"stdin":   c.Stdin,
-				"stdout":  string(stdout),
-				"stderr":  string(stderr),
-				"error":   err,
-			}).Error("TrafPol could not run remove portal ports command")
+			}).Error("TrafPol could not run set allowed ports command")
 		}
 	}
 }

--- a/internal/trafpol/filter_test.go
+++ b/internal/trafpol/filter_test.go
@@ -39,7 +39,6 @@ func TestFilterFunctionsErrors(_ *testing.T) {
 	})
 
 	// portal ports
-	conf.TrafficPolicing.PortalPorts = []uint16{80, 443}
-	addPortalPorts(ctx, conf)
-	removePortalPorts(ctx, conf)
+	setAllowedPorts(ctx, conf, []uint16{80, 443})
+	setAllowedPorts(ctx, conf, []uint16{})
 }

--- a/internal/trafpol/trafpol.go
+++ b/internal/trafpol/trafpol.go
@@ -100,7 +100,7 @@ func (t *TrafPol) handleCPDReport(ctx context.Context, report *cpd.Report) {
 			t.resolver.Resolve()
 
 			// remove ports from allowed ports
-			removePortalPorts(ctx, t.config)
+			setAllowedPorts(ctx, t.config, []uint16{})
 			t.capPortal = false
 			log.WithField("capPortal", t.capPortal).Info("TrafPol changed CPD status")
 		}
@@ -109,7 +109,7 @@ func (t *TrafPol) handleCPDReport(ctx context.Context, report *cpd.Report) {
 
 	// add ports to allowed ports
 	if !t.capPortal {
-		addPortalPorts(ctx, t.config)
+		setAllowedPorts(ctx, t.config, t.config.TrafficPolicing.PortalPorts)
 		t.capPortal = true
 		log.WithField("capPortal", t.capPortal).Info("TrafPol changed CPD status")
 	}


### PR DESCRIPTION
Add the command list "TrafPolSetAllowedPorts" for setting the allowed ports and remove the existing lists "TrafPolAddPortalPorts" and "TrafPolRemovePortalPorts".