### PR TITLE
Update deprecated GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           args: release --snapshot --clean
 
       - name: Store package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: deb-package
           path: |


### PR DESCRIPTION
The GitHub action upload-artifact version 3 is deprecated, so update it to version 4.