### PR TITLE
Update coverage summary GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Process results
         if: always()
-        uses: malaupa/go-test-coverage-summary-action@v2.0.0
+        uses: malaupa/go-test-coverage-summary-action@v3.0.0
         with:
           test_results: "test.out"
           coverage_profile: "cover.out"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Process results
         if: always()
-        uses: malaupa/go-test-coverage-summary-action@v2.0.0
+        uses: malaupa/go-test-coverage-summary-action@v3.0.0
         with:
           test_results: "test.out"
           coverage_profile: "cover.out"


### PR DESCRIPTION
Update the GitHub action malaupa/go-test-coverage-summary-action used for the Go test coverage summary to version 3.