### PR TITLE
Add commands for getting and setting DNS settings to VPNSetup

### DIFF
--- a/internal/cmdtmpl/command.go
+++ b/internal/cmdtmpl/command.go
@@ -479,35 +479,19 @@ add element inet oc-daemon-routing excludes4 { {{.}} }
 			},
 			defaultTemplate: VPNSetupDefaultTemplate,
 		}
-	case "VPNSetupSetupDNSServer":
-		// Setup DNS server
+	case "VPNSetupSetDNS":
+		// Set DNS settings
 		cl = &CommandList{
 			Name: name,
 			Commands: []*Command{
 				{Line: "{{.Executables.Resolvectl}} dns {{.VPNConfig.Device.Name}} {{.DNSProxy.Address}}"},
-			},
-			defaultTemplate: VPNSetupDefaultTemplate,
-		}
-	case "VPNSetupSetupDNSDomains":
-		// Setup DNS domains
-		cl = &CommandList{
-			Name: name,
-			Commands: []*Command{
 				{Line: "{{.Executables.Resolvectl}} domain {{.VPNConfig.Device.Name}} {{.VPNConfig.DNS.DefaultDomain}} ~."},
-			},
-			defaultTemplate: VPNSetupDefaultTemplate,
-		}
-	case "VPNSetupSetupDNSDefaultRoute":
-		// Setup DNS Default Route
-		cl = &CommandList{
-			Name: name,
-			Commands: []*Command{
 				{Line: "{{.Executables.Resolvectl}} default-route {{.VPNConfig.Device}} yes"},
 			},
 			defaultTemplate: VPNSetupDefaultTemplate,
 		}
-	case "VPNSetupEnsureDNS":
-		// Ensure DNS
+	case "VPNSetupGetDNS":
+		// Get DNS settings
 		cl = &CommandList{
 			Name: name,
 			Commands: []*Command{

--- a/internal/cmdtmpl/command_test.go
+++ b/internal/cmdtmpl/command_test.go
@@ -47,10 +47,8 @@ func TestGetCommandList(t *testing.T) {
 		"VPNSetupSetup",
 		"VPNSetupTeardown",
 		"VPNSetupSetExcludes",
-		"VPNSetupSetupDNSServer",
-		"VPNSetupSetupDNSDomains",
-		"VPNSetupSetupDNSDefaultRoute",
-		"VPNSetupEnsureDNS",
+		"VPNSetupSetDNS",
+		"VPNSetupGetDNS",
 		"VPNSetupCleanup",
 	} {
 		cl := getCommandList(name)
@@ -97,10 +95,8 @@ func TestGetCmds(t *testing.T) {
 		"VPNSetupSetup",
 		"VPNSetupTeardown",
 		// "VPNSetupSetExcludes", // skip, requires excludes
-		"VPNSetupSetupDNSServer",
-		"VPNSetupSetupDNSDomains",
-		"VPNSetupSetupDNSDefaultRoute",
-		"VPNSetupEnsureDNS",
+		"VPNSetupSetDNS",
+		"VPNSetupGetDNS",
 		"VPNSetupCleanup",
 	} {
 		if cmds, err := GetCmds(name, daemoncfg.NewConfig()); err != nil ||


### PR DESCRIPTION
Add the command lists "VPNSetupGetDNS" and "VPNSetupSetDNS" for getting and setting the DNS settings to VPNSetup. Remove the existing command lists "VPNSetupSetupDNSServer", "VPNSetupSetupDNSDomains", "VPNSetupSetupDNSDefaultRoute" and "VPNSetupEnsureDNS".