### PR TITLE
Add commands for setting allowed hosts to TrafPol

### DIFF
--- a/internal/cmdtmpl/command.go
+++ b/internal/cmdtmpl/command.go
@@ -225,29 +225,21 @@ add element inet oc-daemon-filter allowdevs { {{.}} }
 			},
 			defaultTemplate: TrafPolDefaultTemplate,
 		}
-	case "TrafPolFlushAllowedHosts":
-		// Flush Allowed Hosts
-		cl = &CommandList{
-			Name: name,
-			Commands: []*Command{
-				{Line: "{{.Executables.Nft}} -f - flush set inet oc-daemon-filter allowhosts4"},
-				{Line: "{{.Executables.Nft}} -f - flush set inet oc-daemon-filter allowhosts6"},
-			},
-			defaultTemplate: TrafPolDefaultTemplate,
-		}
-	case "TrafPolAddAllowedHost":
-		// Add Allowed Host
+	case "TrafPolSetAllowedHosts":
+		// Set Allowed Hosts
 		cl = &CommandList{
 			Name: name,
 			Commands: []*Command{
 				{Line: "{{.Executables.Nft}} -f -",
-					Stdin: `
-				{{if .AllowedIP.Addr.Is4}}
-				add element inet oc-daemon-filter allowhosts4 { {{.AllowedIP}} }
-				{{else}}
-				add element inet oc-daemon-filter allowhosts6 { {{.AllowedIP}} }
-				{{end}}
-				`,
+					Stdin: `flush set inet oc-daemon-filter allowhosts4
+flush set inet oc-daemon-filter allowhosts6
+{{range .AllowedIPs -}}
+{{if .Addr.Is4 -}}
+add element inet oc-daemon-filter allowhosts4 { {{.}} }
+{{else -}}
+add element inet oc-daemon-filter allowhosts6 { {{.}} }
+{{end -}}
+{{end}}`,
 				},
 			},
 			defaultTemplate: TrafPolDefaultTemplate,

--- a/internal/cmdtmpl/command_test.go
+++ b/internal/cmdtmpl/command_test.go
@@ -38,8 +38,7 @@ func TestGetCommandList(t *testing.T) {
 		"TrafPolSetFilterRules",
 		"TrafPolUnsetFilterRules",
 		"TrafPolSetAllowedDevices",
-		"TrafPolFlushAllowedHosts",
-		"TrafPolAddAllowedHost",
+		"TrafPolSetAllowedHosts",
 		"TrafPolSetAllowedPorts",
 		"TrafPolCleanup",
 
@@ -86,8 +85,7 @@ func TestGetCmds(t *testing.T) {
 		"TrafPolSetFilterRules",
 		"TrafPolUnsetFilterRules",
 		// TrafPolSetAllowedDevices", // skip, requires devices
-		"TrafPolFlushAllowedHosts",
-		// "TrafPolAddAllowedHost", // skip, requires host
+		// "TrafPolSetAllowedHosts", // skip, requires hosts
 		//"TrafPolSetAllowedPorts", // skip, requires ports
 		"TrafPolCleanup",
 
@@ -110,7 +108,7 @@ func TestGetCmds(t *testing.T) {
 	for _, name := range []string{
 		// Traffic Policing
 		"TrafPolSetAllowedDevices",
-		"TrafPolAddAllowedHost",
+		"TrafPolSetAllowedHosts",
 		"TrafPolSetAllowedPorts",
 
 		// VPN Setup


### PR DESCRIPTION
Add the command list "TrafPolSetAllowedHosts" for setting the allowed hosts and remove the existing lists "TrafPolFlushAllowedHosts" and "TrafPolAddAllowedHost".