### PR TITLE
Avoid IPv4-mapped IPv6 addresses

### DIFF
--- a/internal/addrmon/addrmon.go
+++ b/internal/addrmon/addrmon.go
@@ -79,7 +79,8 @@ func (a *AddrMon) start() {
 				continue
 			}
 			ones, _ := e.LinkAddress.Mask.Size()
-			addr := netip.PrefixFrom(ip, ones)
+			// unmap to make sure we don't get an IPv4-mapped IPv6 address
+			addr := netip.PrefixFrom(ip.Unmap(), ones)
 			u := &Update{
 				Address: addr,
 				Index:   e.LinkIndex,

--- a/internal/addrmon/addrmon_test.go
+++ b/internal/addrmon/addrmon_test.go
@@ -73,7 +73,13 @@ func TestAddrMonStartStop(t *testing.T) {
 		t.Error(err)
 	}
 	for i := 0; i < 3; i++ {
-		log.Println(<-addrMon.Updates())
+		update := <-addrMon.Updates()
+		log.Println(update)
+
+		// make sure IPv4 address is not IPv4-mapped IPv6 address
+		if update.Address.Addr().Is4In6() {
+			t.Errorf("address is IPv4-mapped IPv6 address: %s", update.Address)
+		}
 	}
 	addrMon.Stop()
 

--- a/internal/daemoncfg/config.go
+++ b/internal/daemoncfg/config.go
@@ -685,7 +685,8 @@ func GetVPNConfig(vpnconf *vpnconfig.Config) *VPNConfig {
 	// convert gateway
 	gateway := netip.Addr{}
 	if g, ok := netip.AddrFromSlice(vpnconf.Gateway); ok {
-		gateway = g
+		// unmap to make sure we don't get an IPv4-mapped IPv6 address
+		gateway = g.Unmap()
 	}
 
 	// convert ipv4 address

--- a/internal/daemoncfg/config_test.go
+++ b/internal/daemoncfg/config_test.go
@@ -620,7 +620,7 @@ func TestGetVPNConfig(t *testing.T) {
 
 	// convert and check
 	got := GetVPNConfig(c)
-	if got.Gateway.Unmap().String() != "192.168.0.1" ||
+	if got.Gateway.String() != "192.168.0.1" ||
 		got.PID != c.PID ||
 		got.Timeout != c.Timeout ||
 		got.Device.Name != c.Device.Name ||

--- a/internal/dnsproxy/proxy.go
+++ b/internal/dnsproxy/proxy.go
@@ -110,7 +110,7 @@ func (p *Proxy) handleRequest(w dns.ResponseWriter, r *dns.Msg) {
 			log.Error("DNS-Proxy received invalid A record in reply")
 			return
 		}
-		addr, ok := netip.AddrFromSlice(rr.A)
+		addr, ok := netip.AddrFromSlice(rr.A.To4())
 		if !ok {
 			log.WithField("A", rr.A).
 				Error("DNS-Proxy received invalid IP in A record in reply")

--- a/internal/dnsproxy/proxy_test.go
+++ b/internal/dnsproxy/proxy_test.go
@@ -126,13 +126,19 @@ func TestProxyHandleRequest(t *testing.T) {
 	}
 
 	// reports should contain the IPv4 and the IPv6 address of example.com
+	wantIPv4 := netip.MustParseAddr("127.0.0.1")
+	wantIPv6 := netip.MustParseAddr("::1")
 	for _, r := range reports {
 		if r.Name != "example.com." {
 			t.Errorf("invalid domain name: %s", r.Name)
 		}
-		if r.IP != netip.MustParseAddr("127.0.0.1") &&
-			r.IP != netip.MustParseAddr("::1") {
+		if r.IP != wantIPv4 && r.IP != wantIPv6 {
 			t.Errorf("invalid IP: %s", r.IP)
+		}
+
+		// make sure IPv4 address is not IPv4-mapped IPv6 address
+		if r.IP == wantIPv4 && r.IP.Is4In6() {
+			t.Errorf("address is IPv4-mapped IPv6 address: %s", r.IP)
 		}
 	}
 }


### PR DESCRIPTION
Avoid IPv4-mapped IPv6 addresses when converting from net.IP to
netip.Addr by using the To4() and Unmap() methods.