### PR TITLE
Add support for loading command lists from file

### DIFF
--- a/internal/daemon/cmd.go
+++ b/internal/daemon/cmd.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/telekom-mms/oc-daemon/internal/cmdtmpl"
 	"github.com/telekom-mms/oc-daemon/internal/daemoncfg"
 )
 
@@ -86,6 +87,14 @@ func run(args []string) error {
 	if !config.Valid() {
 		config = daemoncfg.NewConfig()
 		log.Warn("Daemon loaded invalid config, using default config")
+	}
+
+	// load command lists
+	if err := cmdtmpl.LoadCommandLists(config.CommandLists.ListsFile); err != nil {
+		log.WithError(err).Debug("Daemon did not load command lists, using defaults")
+	} else {
+		log.WithField("file", config.CommandLists.ListsFile).
+			Info("Daemon loaded command lists from file")
 	}
 
 	// check executables

--- a/internal/daemon/cmd_test.go
+++ b/internal/daemon/cmd_test.go
@@ -84,6 +84,30 @@ func TestRun(t *testing.T) {
 		t.Errorf("start should return error")
 	}
 
+	// not existing command lists file
+	cmdListsFile := filepath.Join(dir, "cmd-lists")
+	cmdListsConf := fmt.Sprintf(`{
+	"CommandLists": {
+		"ListsFile": "%s"
+	}
+}
+	`, cmdListsFile)
+	if err := os.WriteFile(cfg, []byte(cmdListsConf), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := run([]string{"test", "-verbose", "-config", cfg}); err == nil {
+		t.Errorf("start should return error")
+	}
+
+	// minimum command lists file
+	if err := os.WriteFile(cmdListsFile, []byte("[]"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := run([]string{"test", "-verbose", "-config", cfg}); err == nil {
+		t.Errorf("start should return error")
+	}
+
 	// not existing executables
 	if err := os.WriteFile(cfg, []byte(fmt.Sprintf(`{
 	"Executables": {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/telekom-mms/oc-daemon/internal/api"
+	"github.com/telekom-mms/oc-daemon/internal/cmdtmpl"
 	"github.com/telekom-mms/oc-daemon/internal/daemoncfg"
 	"github.com/telekom-mms/oc-daemon/internal/dbusapi"
 	"github.com/telekom-mms/oc-daemon/internal/dnsproxy"
@@ -530,6 +531,7 @@ func (d *Daemon) dumpState() string {
 		DaemonConfig    *daemoncfg.Config
 		TrafficPolicing *trafpol.State
 		VPNSetup        *vpnsetup.State
+		CommandLists    map[string]*cmdtmpl.CommandList
 	}
 
 	// collect internal state
@@ -537,6 +539,7 @@ func (d *Daemon) dumpState() string {
 	c.LoginInfo.Cookie = "HIDDEN" // hide cookie
 	state := State{
 		DaemonConfig: c,
+		CommandLists: cmdtmpl.CommandLists,
 	}
 	if d.trafpol != nil {
 		state.TrafficPolicing = d.trafpol.GetState()

--- a/internal/daemoncfg/config.go
+++ b/internal/daemoncfg/config.go
@@ -527,6 +527,39 @@ func NewTrafficPolicing() *TrafficPolicing {
 	}
 }
 
+// Command lists default values
+var (
+	CommandListsListsFile = configDir + "/command-lists.json"
+)
+
+// CommandLists is the command lists configuration.
+type CommandLists struct {
+	ListsFile string
+}
+
+// Copy returns a copy of the command lists configuration.
+func (c *CommandLists) Copy() *CommandLists {
+	n := *c
+	return &n
+}
+
+// Valid returns whether the command lists configuration is valid.
+func (c *CommandLists) Valid() bool {
+	if c == nil ||
+		c.ListsFile == "" {
+
+		return false
+	}
+	return true
+}
+
+// NewCommandLists returns a new command lists configuration.
+func NewCommandLists() *CommandLists {
+	return &CommandLists{
+		ListsFile: CommandListsListsFile,
+	}
+}
+
 // VPNDevice is a VPN device configuration in VPNConfig.
 type VPNDevice struct {
 	Name string
@@ -790,6 +823,8 @@ type Config struct {
 	TrafficPolicing *TrafficPolicing
 	TND             *tnd.Config
 
+	CommandLists *CommandLists
+
 	LoginInfo *logininfo.LoginInfo
 	VPNConfig *VPNConfig
 }
@@ -809,6 +844,8 @@ func (c *Config) Copy() *Config {
 		SplitRouting:    c.SplitRouting.Copy(),
 		TrafficPolicing: c.TrafficPolicing.Copy(),
 		TND:             &t,
+
+		CommandLists: c.CommandLists.Copy(),
 
 		LoginInfo: c.LoginInfo.Copy(),
 		VPNConfig: c.VPNConfig.Copy(),
@@ -838,6 +875,7 @@ func (c *Config) Valid() bool {
 		!c.SplitRouting.Valid() ||
 		!c.TrafficPolicing.Valid() ||
 		!c.TND.Valid() ||
+		!c.CommandLists.Valid() ||
 		!loginInfoEmpty(c.LoginInfo) && !c.LoginInfo.Valid() ||
 		!c.VPNConfig.Valid() {
 		// invalid
@@ -900,6 +938,8 @@ func NewConfig() *Config {
 		SplitRouting:    NewSplitRouting(),
 		TrafficPolicing: NewTrafficPolicing(),
 		TND:             tnd.NewConfig(),
+
+		CommandLists: NewCommandLists(),
 
 		LoginInfo: &logininfo.LoginInfo{},
 		VPNConfig: &VPNConfig{},

--- a/internal/daemoncfg/config_test.go
+++ b/internal/daemoncfg/config_test.go
@@ -833,6 +833,9 @@ func TestConfigLoad(t *testing.T) {
 		"HTTPSTimeout": 5000000000,
 		"UntrustedTimer": 30000000000,
 		"TrustedTimer": 60000000000
+	},
+	"CommandLists": {
+		"ListsFile": "/var/lib/oc-daemon/command-lists.json"
 	}
 }`,
 		`{
@@ -873,6 +876,7 @@ func TestConfigLoad(t *testing.T) {
 			SplitRouting:    NewSplitRouting(),
 			TrafficPolicing: NewTrafficPolicing(),
 			TND:             tnd.NewConfig(),
+			CommandLists:    NewCommandLists(),
 			LoginInfo:       &logininfo.LoginInfo{},
 			VPNConfig:       &VPNConfig{},
 		}
@@ -913,6 +917,7 @@ func TestNewConfig(t *testing.T) {
 		SplitRouting:    NewSplitRouting(),
 		TrafficPolicing: NewTrafficPolicing(),
 		TND:             tnd.NewConfig(),
+		CommandLists:    NewCommandLists(),
 		LoginInfo:       &logininfo.LoginInfo{},
 		VPNConfig:       &VPNConfig{},
 	}


### PR DESCRIPTION
Add support for loading command lists from a file. The file can contain a subset or all command lists. Only command lists in the file are changed. The remaining command lists keep their default values. The default path of the file is /var/lib/oc-daemon/command-lists.json and can be changed in the OC-Daemon configuration file.