### PR TITLE
Ignore invalid entries in OC-Daemon configuration file

### DIFF
--- a/internal/daemoncfg/config.go
+++ b/internal/daemoncfg/config.go
@@ -3,7 +3,6 @@ package daemoncfg
 
 import (
 	"encoding/json"
-	"errors"
 	"net/netip"
 	"os"
 	"os/exec"
@@ -815,7 +814,7 @@ var (
 
 // Config is an OC-Daemon configuration.
 type Config struct {
-	Config  string
+	Config  string `json:"-"`
 	Verbose bool
 
 	SocketServer    *SocketServer
@@ -829,8 +828,8 @@ type Config struct {
 
 	CommandLists *CommandLists
 
-	LoginInfo *logininfo.LoginInfo
-	VPNConfig *VPNConfig
+	LoginInfo *logininfo.LoginInfo `json:"-"`
+	VPNConfig *VPNConfig           `json:"-"`
 }
 
 // Copy returns a copy of the configuration.
@@ -896,36 +895,8 @@ func (c *Config) Load() error {
 		return err
 	}
 
-	// save current values to detect not allowed config file entries
-	oldConfig := c.Config
-	c.Config = ""
-	oldLoginInfo := c.LoginInfo
-	c.LoginInfo = nil
-	oldVPNConfig := c.VPNConfig
-	c.VPNConfig = nil
-
 	// parse config
-	if err := json.Unmarshal(file, c); err != nil {
-		return err
-	}
-
-	// check not allowed entries in config file
-	if c.Config != "" {
-		return errors.New("configuration file must not include Config")
-	}
-	if c.LoginInfo != nil {
-		return errors.New("configuration file must not include LoginInfo")
-	}
-	if c.VPNConfig != nil {
-		return errors.New("configuration file must not include VPNConfig")
-	}
-
-	// reset saved values
-	c.Config = oldConfig
-	c.LoginInfo = oldLoginInfo
-	c.VPNConfig = oldVPNConfig
-
-	return nil
+	return json.Unmarshal(file, c)
 }
 
 // NewConfig returns a new Config.

--- a/internal/daemoncfg/config_test.go
+++ b/internal/daemoncfg/config_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -731,10 +730,10 @@ func TestConfigLoad(t *testing.T) {
 		t.Errorf("got != nil, want nil")
 	}
 
-	// test invalid config files
-	// - with Config
-	// - with LoginInfo
-	// - with VPNConfig
+	// test invalid config file entries
+	// - Config
+	// - LoginInfo
+	// - VPNConfig
 	for _, content := range []string{
 		`{
 	"Config": "should not be here",
@@ -767,9 +766,14 @@ func TestConfigLoad(t *testing.T) {
 
 		conf := NewConfig()
 		conf.Config = invalid.Name()
-		if err := conf.Load(); err == nil ||
-			!strings.HasPrefix(err.Error(), "configuration file must not include") {
-			t.Errorf("should not load invalid config: %s", content)
+		if err := conf.Load(); err != nil {
+			t.Error(err)
+		}
+		// make sure invalid file entries did not change config
+		if conf.Config != invalid.Name() ||
+			conf.LoginInfo.Server != "" ||
+			conf.VPNConfig.Gateway.IsValid() {
+			t.Errorf("loaded config with invalid entry: %s", content)
 		}
 	}
 


### PR DESCRIPTION
Ignore invalid entries when parsing the OC-Daemon configuration file and remove extra checks.