### PR TITLE
Wait until VPN is disconnected during OC-Client reconnect

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -131,7 +131,7 @@ func reconnectVPN() error {
 		}
 
 		if !status.TrustedNetwork.Trusted() &&
-			!status.ConnectionState.Connected() &&
+			status.ConnectionState.Disconnected() &&
 			!status.OCRunning.Running() {
 			// authenticate and connect
 			return connectVPN()

--- a/pkg/vpnstatus/status.go
+++ b/pkg/vpnstatus/status.go
@@ -47,9 +47,19 @@ const (
 	ConnectionStateDisconnecting
 )
 
+// Connecting returns whether ConnectionState is state "connecting".
+func (c ConnectionState) Connecting() bool {
+	return c == ConnectionStateConnecting
+}
+
 // Connected returns whether ConnectionState is state "connected".
 func (c ConnectionState) Connected() bool {
 	return c == ConnectionStateConnected
+}
+
+// Disconnected returns whether ConnectionState is state "disconnected".
+func (c ConnectionState) Disconnected() bool {
+	return c == ConnectionStateDisconnected
 }
 
 // String returns ConnectionState as string.

--- a/pkg/vpnstatus/status_test.go
+++ b/pkg/vpnstatus/status_test.go
@@ -42,6 +42,26 @@ func TestTrustedNetworkString(t *testing.T) {
 	}
 }
 
+// TestConnectionStateConnecting tests Connecting of ConnectionState.
+func TestConnectionStateConnecting(t *testing.T) {
+	// test not connecting
+	for i, notConnecting := range []ConnectionState{
+		ConnectionStateUnknown,
+		ConnectionStateDisconnected,
+		ConnectionStateConnected,
+		ConnectionStateDisconnecting,
+	} {
+		if notConnecting.Connecting() {
+			t.Errorf("should not be connecting: %d, %s", i, notConnecting)
+		}
+	}
+
+	// test connecting
+	if !ConnectionStateConnecting.Connecting() {
+		t.Errorf("should be connecting: %s", ConnectionStateConnecting)
+	}
+}
+
 // TestConnectionStateConnected tests Connected of ConnectionState.
 func TestConnectionStateConnected(t *testing.T) {
 	// test not connected
@@ -59,6 +79,26 @@ func TestConnectionStateConnected(t *testing.T) {
 	// test connected
 	if !ConnectionStateConnected.Connected() {
 		t.Errorf("should be connected: %s", ConnectionStateConnected)
+	}
+}
+
+// TestConnectionStateDisconnected tests Disconnected of ConnectionState.
+func TestConnectionStateDisconnected(t *testing.T) {
+	// test not disconnected
+	for i, notDisconnected := range []ConnectionState{
+		ConnectionStateUnknown,
+		ConnectionStateConnecting,
+		ConnectionStateConnected,
+		ConnectionStateDisconnecting,
+	} {
+		if notDisconnected.Disconnected() {
+			t.Errorf("should not be disconnected: %d, %s", i, notDisconnected)
+		}
+	}
+
+	// test disconnected
+	if !ConnectionStateDisconnected.Disconnected() {
+		t.Errorf("should be disconnected: %s", ConnectionStateDisconnected)
 	}
 }
 


### PR DESCRIPTION
The OC-Client reconnect command sends a disconnect request to OC-Daemon, waits for the current VPN connection to be terminated and then sends a new connect request. Currently, the client is able to send the connect request before the connection is completely shut down which causes the reconnect command to fail. So, wait in OC-Client until OC-Daemon reaches state "disconnected" and OpenConnect is not running any more before connecting again. Additionally, set the "disconnected" and "OpenConnect not running" states later in OC-Daemon.