### PR TITLE
Add ocserv tests

### DIFF
--- a/scripts/build-podman-test.sh
+++ b/scripts/build-podman-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# This script is a podman version of the goreleaser build script "build.sh"
+# that uses an alternative goreleaser configuration that enables the race
+# detector and coverage in the binaries.
+# It should be run from the root directory of the git repository.
+
+# set target directory in container
+TARGET=/code
+
+# run container
+podman run \
+	--rm \
+	--mount type=bind,source="$PWD",target="$TARGET" \
+	--workdir "$TARGET" \
+	--env GOCACHE=/tmp \
+	docker.io/goreleaser/goreleaser \
+	release \
+	--snapshot \
+	--clean \
+	--config "test/ocserv/oc-daemon/goreleaser.yml"

--- a/scripts/build-podman.sh
+++ b/scripts/build-podman.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# This script is a podman version of the goreleaser build script "build.sh".
+# It should be run from the root directory of the git repository.
+
+# set target directory in container
+TARGET=/code
+
+# run container
+podman run \
+	--rm \
+	--mount type=bind,source="$PWD",target="$TARGET" \
+	--workdir "$TARGET" \
+	--env GOCACHE=/tmp \
+	docker.io/goreleaser/goreleaser \
+	release \
+	--snapshot \
+	--clean

--- a/test/ocserv/.gitignore
+++ b/test/ocserv/.gitignore
@@ -1,0 +1,2 @@
+/gocover
+/tests.log

--- a/test/ocserv/README.md
+++ b/test/ocserv/README.md
@@ -1,0 +1,163 @@
+# Tests with ocserv
+
+These tests test OC-Daemon with [ocserv][ocserv] in a test setup with two
+networks and multiple nodes created with podman-compose.
+
+## Requirements
+
+- podman
+  - tested with version 4.3.1 (Debian 12) and 5.4.1
+  - [rootless][rootless] with configured [subuid/subgid][subuid] for your user
+- podman-compose
+
+## Quick Run
+
+Run in the root directory of the Git repository:
+
+- Build Debian package with `./scripts/build-podman-test.sh`
+- Run all tests with `./test/ocserv/tests.sh all`
+
+Important: remember to re-build the Debian package before running the tests
+when the OC-Daemon code changed.
+
+See Examples below for other build options, running specific tests etc.
+
+## Test Setup
+
+The test setup is shown in the following figure:
+
+```
+.........................................................................
+: oc-daemon-test-                   :                   oc-daemon-test- :
+: ext                               :                               int :
+:   _________________               :                                   :
+:  |                 |              :                                   :
+:  | oc-daemon-test- |__            :                                   :
+:  | oc-daemon       |  |   ________:________       _________________   :
+:  |_________________|  |  |                 |     |                 |  :
+:                       |__| oc-daemon-test- |_____| oc-daemon-test- |  :
+:   _________________   |  | ocserv          |     | web-int         |  :
+:  |                 |  |  |_________________|     |_________________|  :
+:  | oc-daemon-test- |__|           :                                   :
+:  | web-ext         |              :                                   :
+:  |_________________|              :                                   :
+:                                   :                                   :
+:...................................:...................................:
+```
+
+The test setup consists of the two networks `oc-daemon-test-ext` and
+`oc-daemon-test-int` as well as the four nodes (services, containers)
+`oc-daemon-test-oc-daemon`, `oc-daemon-test-web-ext`, `oc-daemon-test-ocserv`
+and `oc-daemon-test-web-int`. For brevity, the common prefix `oc-daemon-test-`
+in the names is omitted in the following description. `oc-daemon` and `web-ext`
+are only in network `ext`. `web-int` is only in network `int`. `ocserv` is in
+both networks. `oc-daemon` runs OC-Daemon and acts as VPN client. `ocserv` runs
+[ocserv][ocserv] and acts as VPN server. `web-ext` and `web-int` both run
+[Caddy][caddy] and act as web servers with HTTPS, so they can also be used as
+TND servers. `ocserv` connects VPN clients to the network `int` and, thus, to
+`web-int`. So, `oc-daemon` can reach `web-int` when it is connected to the VPN
+via `ocserv`. Otherwise, it can only reach `web-ext`. So, `ext` acts as
+external, untrusted network and `int` as internal, trusted network.
+
+Currently, there are two versions of the test setup: the IPv4 version and the
+IPv6 version. In the IPv4 version, the nodes only use IPv4 addresses. In the
+IPv6 version, the nodes use both IPv4 and IPv6 addresses.
+
+The test setup versions are used by the individual tests. Each test is
+responsible for starting and stopping the test setup and running the steps
+necessary for the specific test like setting a configuration, connecting and
+disconnecting the VPN as well as running checks. For example, a test can run
+steps similar to the following:
+
+- start networks and containers
+- configure routing on `ocserv`
+- run checks without VPN connection on `oc-daemon`
+  - connectivity to `web-ext` and `web-int` with ping and curl
+  - errors in OC-Daemon logs
+- establish VPN connection on `oc-daemon`
+- run checks with VPN connection on `oc-daemon`
+  - connectivity to `web-ext` and `web-int` with ping and curl
+  - errors in OC-Daemon logs
+- stop networks and containers
+
+See test cases in `tests.sh` for more info on the specific tests.
+
+## Examples
+
+### Building OC-Daemon for Tests
+
+Building Debian package of regular OC-Daemon version:
+
+```console
+$ ./scripts/build-podman.sh
+```
+
+Building Debian package of OC-Daemon with race detector and coverage enabled
+(recommended for testing):
+
+```console
+$ ./scripts/build-podman-test.sh
+```
+
+### Running all Tests
+
+Running all tests:
+
+```console
+$ ./test/ocserv/tests.sh all
+```
+
+### Listing available Tests
+
+Listing all available test:
+
+```console
+$ ./test/ocserv/tests.sh list
+test_default test_default_ipv6 test_splitrt test_splitrt_ipv6 test_restart
+test_reconnect test_disconnect test_occlient_config test_profile_alwayson
+test_profile_tnd
+```
+
+### Running specific Test
+
+Running specific test `test_default`:
+
+```console
+$ ./test/ocserv/tests.sh test_default
+```
+
+### Viewing more Test Output
+
+You can view more detailed test output in the log file
+`./tests/ocserv/tests.log`, e.g.:
+
+```console
+$ less ./tests/ocserv/tests.log
+```
+
+### Starting and Stopping Test Setup
+
+Starting the test setup without running any tests, e.g., for debugging:
+
+```console
+$ # IPv4 version
+$ ./test/ocserv/tests.sh up ipv4
+$ # or IPv6 version
+$ ./test/ocserv/tests.sh up ipv6
+```
+
+Remember to stop the test setup before running tests.
+
+Stopping the test setup:
+
+```console
+$ # IPv4 version
+$ ./test/ocserv/tests.sh down ipv4
+$ # or IPv6 version
+$ ./test/ocserv/tests.sh down ipv6
+```
+
+[ocserv]: https://ocserv.openconnect-vpn.net/
+[rootless]: https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md
+[subuid]: https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md#etcsubuid-and-etcsubgid-configuration
+[caddy]: https://caddyserver.com/

--- a/test/ocserv/certs/ca.tmpl
+++ b/test/ocserv/certs/ca.tmpl
@@ -1,0 +1,8 @@
+cn = "test certificate authority"
+organization = "test organization"
+serial = 1
+expiration_days = 3650
+ca
+signing_key
+cert_signing_key
+crl_signing_key

--- a/test/ocserv/certs/oc-daemon.tmpl
+++ b/test/ocserv/certs/oc-daemon.tmpl
@@ -1,0 +1,9 @@
+cn = "oc-daemon-test-oc-daemon"
+organization = "test organization"
+serial = 1
+expiration_days = 3650
+signing_key
+encryption_key
+tls_www_server
+dns_name = "oc-daemon-test-oc-daemon"
+uid = "test_user"

--- a/test/ocserv/certs/ocserv.tmpl
+++ b/test/ocserv/certs/ocserv.tmpl
@@ -1,0 +1,8 @@
+cn = "oc-daemon-test-ocserv"
+organization = "test organization"
+serial = 2
+expiration_days = 3650
+signing_key
+encryption_key
+tls_www_server
+dns_name = "oc-daemon-test-ocserv"

--- a/test/ocserv/certs/web-ext.tmpl
+++ b/test/ocserv/certs/web-ext.tmpl
@@ -1,0 +1,8 @@
+cn = "oc-daemon-test-web-ext"
+organization = "test organization"
+serial = 2
+expiration_days = 3650
+signing_key
+encryption_key
+tls_www_server
+dns_name = "oc-daemon-test-web-ext"

--- a/test/ocserv/certs/web-int.tmpl
+++ b/test/ocserv/certs/web-int.tmpl
@@ -1,0 +1,8 @@
+cn = "oc-daemon-test-web-int"
+organization = "test organization"
+serial = 2
+expiration_days = 3650
+signing_key
+encryption_key
+tls_www_server
+dns_name = "oc-daemon-test-web-int"

--- a/test/ocserv/oc-daemon/goreleaser.yml
+++ b/test/ocserv/oc-daemon/goreleaser.yml
@@ -1,0 +1,151 @@
+version: 2
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - id: oc-client
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+    main: ./cmd/oc-client/main.go
+    binary: oc-client
+    flags:
+      - -race
+      - -cover
+    ldflags:
+      - -s -w -X github.com/telekom-mms/oc-daemon/internal/daemon.Version={{.Version}}-{{.Commit}}
+  - id: oc-daemon
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+    main: ./cmd/oc-daemon/main.go
+    binary: oc-daemon
+    flags:
+      - -race
+      - -cover
+    ldflags:
+      - -s -w -X github.com/telekom-mms/oc-daemon/internal/daemon.Version={{.Version}}-{{.Commit}}
+  - id: oc-daemon-vpncscript
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+    goarch:
+      - amd64
+    main: ./cmd/oc-daemon-vpncscript/main.go
+    binary: oc-daemon-vpncscript
+    flags:
+      - -race
+      - -cover
+    ldflags:
+      - -s -w -X github.com/telekom-mms/oc-daemon/internal/daemon.Version={{.Version}}-{{.Commit}}
+archives:
+  - formats:
+      - tar.gz
+    wrap_in_directory: true
+    files:
+      - src: init/oc-daemon.service
+        dst: systemd/oc-daemon.service
+        info:
+          mode: 0644
+      - src: configs/oc-client.json
+        dst: examples/oc-client.json
+        info:
+          mode: 0644
+      - src: configs/oc-daemon.json
+        dst: examples/oc-daemon.json
+        info:
+          mode: 0644
+      - src: configs/dbus/com.telekom_mms.oc_daemon.Daemon.conf
+        dst: dbus/com.telekom_mms.oc_daemon.Daemon.conf
+        info:
+          mode: 0644
+      - docs
+      - README.md
+      - LICENSE
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  version_template: "{{ incpatch .Version }}-n{{ .Timestamp }}"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+nfpms:
+  - package_name: oc-daemon
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}"
+    vendor: Deutsche Telekom MMS GmbH
+    maintainer: The MMS Linux Dev Team <mmslinux-dev@t-systems-mms.com>
+    description: |-
+      OpenConnect Daemon
+      Wraps OpenConnect to enhance functionality for corporate Linux clients.
+    license: MIT
+    formats:
+      - deb
+    dependencies:
+      - "nftables"
+      - "openconnect"
+      - "init-system-helpers (>= 1.62)"
+    bindir: /usr/bin
+    section: net
+    # important: this makes the package non native
+    release: "1"
+    priority: important
+    # chglog init -> generates changelog.yml
+    # chglog add --version v#.#.# -> after every tag, call in hook above?
+    # activate if https://github.com/goreleaser/nfpm/pull/656 is merged and used in goreleaser
+    # -> remove overrides
+    # changelog: "changelog.yml"
+    scripts:
+      postinstall: build/package/postinstall.sh
+      preremove: build/package/preremove.sh
+      postremove: build/package/postremove.sh
+    deb:
+      lintian_overrides:
+        - "no-manual-page"
+        - "no-changelog"
+        - "statically-linked-binary"
+    contents:
+      - src: init/oc-daemon.service
+        dst: /lib/systemd/system/
+        file_info:
+          mode: 0644
+      - src: configs/dbus/com.telekom_mms.oc_daemon.Daemon.conf
+        dst: /usr/share/dbus-1/system.d/
+        file_info:
+          mode: 0644
+      - src: configs/oc-client.json
+        dst: /usr/share/doc/oc-daemon/examples/
+        file_info:
+          mode: 0644
+      - src: configs/oc-daemon.json
+        dst: /usr/share/doc/oc-daemon/examples/
+        file_info:
+          mode: 0644
+      - src: copyright
+        dst: /usr/share/doc/oc-daemon/
+        file_info:
+          mode: 0644
+      - src: docs
+        dst: /usr/share/doc/oc-daemon/docs
+        file_info:
+          mode: 0755
+      - src: README.md
+        dst: /usr/share/doc/oc-daemon/
+        file_info:
+          mode: 0644
+      - src: LICENSE
+        dst: /usr/share/doc/oc-daemon/
+        file_info:
+          mode: 0644
+release:
+  prerelease: auto
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/test/ocserv/oc-daemon/profile.xml
+++ b/test/ocserv/oc-daemon/profile.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AnyConnectProfile xmlns="http://schemas.xmlsoap.org/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.xmlsoap.org/encoding/ AnyConnectProfile.xsd">
+	<ClientInitialization>
+		<AutomaticVPNPolicy>true
+			<TrustedDNSDomains></TrustedDNSDomains>
+			<TrustedDNSServers></TrustedDNSServers>
+			<TrustedHttpsServerList>
+				<TrustedHttpsServer>
+					<Address>WEB_SERVER</Address>
+					<Port>443</Port>
+					<CertificateHash>CERT_HASH</CertificateHash>
+				</TrustedHttpsServer>
+			</TrustedHttpsServerList>
+			<TrustedNetworkPolicy>Disconnect</TrustedNetworkPolicy>
+			<UntrustedNetworkPolicy>DoNothing</UntrustedNetworkPolicy>
+			<AlwaysOn>true
+				<ConnectFailurePolicy>Closed
+					<AllowCaptivePortalRemediation>true
+						<CaptivePortalRemediationTimeout>5</CaptivePortalRemediationTimeout>
+					</AllowCaptivePortalRemediation>
+					<ApplyLastVPNLocalResourceRules>false</ApplyLastVPNLocalResourceRules>
+				</ConnectFailurePolicy>
+				<AllowVPNDisconnect>true</AllowVPNDisconnect>
+				<AllowedHosts>ocserv</AllowedHosts>
+			</AlwaysOn>
+		</AutomaticVPNPolicy>
+	</ClientInitialization>
+	<ServerList>
+		<HostEntry>
+			<HostName>oc-daemon-test-ocserv</HostName>
+			<HostAddress>oc-daemon-test-ocserv</HostAddress>
+			<UserGroup></UserGroup>
+			<LoadBalancingServerList>
+				<HostAddress>oc-daemon-test-ocserv</HostAddress>
+			</LoadBalancingServerList>
+		</HostEntry>
+	</ServerList>
+</AnyConnectProfile>

--- a/test/ocserv/ocserv/ocserv.conf
+++ b/test/ocserv/ocserv/ocserv.conf
@@ -1,0 +1,56 @@
+### The following directives do not change with server reload.
+
+auth = "certificate"
+tcp-port = 443
+udp-port = 443
+run-as-user = ocserv
+run-as-group = ocserv
+socket-file = /run/ocserv-socket
+chroot-dir = /var/lib/ocserv
+server-cert = /etc/ocserv/server-cert.pem
+server-key = /etc/ocserv/server-key.pem
+ca-cert = /etc/ocserv/ca-cert.pem
+
+### All configuration options below this line are reloaded on a SIGHUP.
+### The options above, will remain unchanged. Note however, that the
+### server-cert, server-key, dh-params and ca-cert options will be reloaded
+### if the provided file changes, on server reload. That allows certificate
+### rotation, but requires the server key to remain the same for seamless
+### operation. If the server key changes on reload, there may be connection
+### failures during the reloading time.
+
+isolate-workers = true
+max-clients = 16
+max-same-clients = 2
+rate-limit-ms = 100
+server-stats-reset-time = 604800
+keepalive = 32400
+dpd = 90
+mobile-dpd = 1800
+switch-to-tcp-timeout = 25
+try-mtu-discovery = false
+cert-user-oid = 0.9.2342.19200300.100.1.1
+tls-priorities = "NORMAL:%SERVER_PRECEDENCE:%COMPAT:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.3"
+auth-timeout = 240
+min-reauth-time = 300
+max-ban-score = 80
+ban-reset-time = 1200
+cookie-timeout = 300
+deny-roaming = false
+rekey-time = 172800
+rekey-method = ssl
+use-occtl = true
+pid-file = /run/ocserv.pid
+log-level = 1
+device = vpns
+predictable-ips = true
+default-domain = example.com
+ipv4-network = 192.168.1.0
+ipv4-netmask = 255.255.255.0
+dns = 192.168.1.1
+ping-leases = false
+route = default
+#user-profile = profile.xml
+cisco-client-compat = true
+dtls-legacy = true
+client-bypass-protocol = false

--- a/test/ocserv/podman/Dockerfile
+++ b/test/ocserv/podman/Dockerfile
@@ -1,0 +1,106 @@
+# builder for certificates
+FROM docker.io/library/debian:12-slim AS certs
+
+COPY \
+test/ocserv/certs/ca.tmpl \
+test/ocserv/certs/ocserv.tmpl \
+test/ocserv/certs/oc-daemon.tmpl \
+test/ocserv/certs/web-ext.tmpl \
+test/ocserv/certs/web-int.tmpl \
+/
+
+RUN \
+apt-get update && \
+apt-get install -y gnutls-bin && \
+certtool --generate-privkey --outfile /ca-key.pem && \
+certtool --generate-self-signed \
+	--load-privkey /ca-key.pem \
+	--template /ca.tmpl \
+	--outfile /ca-cert.pem && \
+certtool --generate-privkey --outfile /server-key.pem && \
+certtool --generate-certificate \
+	--load-privkey /server-key.pem \
+	--load-ca-certificate /ca-cert.pem \
+	--load-ca-privkey /ca-key.pem \
+	--template /ocserv.tmpl \
+	--outfile /server-cert.pem && \
+certtool --generate-privkey --outfile /client-key.pem && \
+certtool --generate-certificate \
+	--load-privkey /client-key.pem \
+	--load-ca-certificate /ca-cert.pem \
+	--load-ca-privkey /ca-key.pem \
+	--template /oc-daemon.tmpl \
+	--outfile /client-cert.pem && \
+certtool --generate-privkey --outfile /web-ext-key.pem && \
+certtool --generate-certificate \
+	--load-privkey /web-ext-key.pem \
+	--load-ca-certificate /ca-cert.pem \
+	--load-ca-privkey /ca-key.pem \
+	--template /web-ext.tmpl \
+	--outfile /web-ext-cert.pem && \
+certtool --fingerprint \
+	--infile /web-ext-cert.pem \
+	--hash sha256 \
+	--outfile=/web-ext-cert.sum && \
+certtool --generate-privkey --outfile /web-int-key.pem && \
+certtool --generate-certificate \
+	--load-privkey /web-int-key.pem \
+	--load-ca-certificate /ca-cert.pem \
+	--load-ca-privkey /ca-key.pem \
+	--template /web-int.tmpl \
+	--outfile /web-int-cert.pem && \
+certtool --fingerprint \
+	--infile /web-int-cert.pem \
+	--hash sha256 \
+	--outfile=/web-int-cert.sum
+
+# ocserv
+FROM docker.io/library/debian:12-slim AS ocserv
+
+EXPOSE 443/tcp
+EXPOSE 443/udp
+
+RUN \
+apt-get update && \
+apt-get install -y ocserv
+
+COPY --from=certs /ca-cert.pem /server-key.pem /server-cert.pem /etc/ocserv/
+COPY test/ocserv/ocserv/ocserv.conf /etc/ocserv/
+
+CMD ["ocserv", "-f"]
+
+# oc-daemon
+FROM docker.io/library/debian:12-slim AS oc-daemon
+
+COPY --from=certs /ca-cert.pem /client-key.pem /client-cert.pem /
+
+COPY dist/oc-daemon*.deb /
+
+RUN \
+apt-get update && \
+apt-get install -y /*.deb && \
+apt-get install -y procps systemd systemd-sysv systemd-resolved iputils-ping curl musl && \
+systemctl enable oc-daemon.service && \
+mkdir /gocover && \
+mkdir /etc/systemd/system/oc-daemon.service.d && \
+echo "[Service]\nEnvironment=\"GOCOVERDIR=/gocover\"" > /etc/systemd/system/oc-daemon.service.d/gocover.conf
+
+CMD [ "/sbin/init" ]
+
+# web-ext
+FROM docker.io/library/caddy:latest AS web-ext
+
+COPY test/ocserv/web/Caddyfile /etc/caddy/Caddyfile
+COPY --from=certs /ca-cert.pem /
+COPY --from=certs /web-ext-key.pem /web-key.pem
+COPY --from=certs /web-ext-cert.pem /web-cert.pem
+COPY --from=certs /web-ext-cert.sum /web-cert.sum
+
+# web-int
+FROM docker.io/library/caddy:latest AS web-int
+
+COPY test/ocserv/web/Caddyfile /etc/caddy/Caddyfile
+COPY --from=certs /ca-cert.pem /
+COPY --from=certs /web-int-key.pem /web-key.pem
+COPY --from=certs /web-int-cert.pem /web-cert.pem
+COPY --from=certs /web-int-cert.sum /web-cert.sum

--- a/test/ocserv/podman/compose-ipv6.yml
+++ b/test/ocserv/podman/compose-ipv6.yml
@@ -1,0 +1,63 @@
+# test network with ipv4 and ipv6
+name: oc-daemon-test
+
+services:
+  ocserv:
+    build:
+      context: ../../../
+      dockerfile: test/ocserv/podman/Dockerfile
+      target: ocserv
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW # for ping
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    networks:
+      - ext
+      - int
+    container_name: oc-daemon-test-ocserv
+  oc-daemon:
+    build:
+      context: ../../../
+      dockerfile: test/ocserv/podman/Dockerfile
+      target: oc-daemon
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    networks:
+      - ext
+    container_name: oc-daemon-test-oc-daemon
+    environment:
+      - GOCOVERDIR=/gocover
+  web-ext:
+    build:
+      context: ../../../
+      dockerfile: test/ocserv/podman/Dockerfile
+      target: web-ext
+    networks:
+      - ext
+    container_name: oc-daemon-test-web-ext
+  web-int:
+    build:
+      context: ../../../
+      dockerfile: test/ocserv/podman/Dockerfile
+      target: web-int
+    cap_add:
+      - NET_ADMIN
+    networks:
+      - int
+    container_name: oc-daemon-test-web-int
+
+networks:
+  ext:
+    internal: true
+    enable_ipv6: true
+    name: oc-daemon-test-ext
+  int:
+    internal: true
+    enable_ipv6: true
+    name: oc-daemon-test-int

--- a/test/ocserv/podman/compose.yml
+++ b/test/ocserv/podman/compose.yml
@@ -1,0 +1,61 @@
+# test network with ipv4 only
+name: oc-daemon-test
+
+services:
+  ocserv:
+    build:
+      context: ../../../
+      dockerfile: test/ocserv/podman/Dockerfile
+      target: ocserv
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW # for ping
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    networks:
+      - ext
+      - int
+    container_name: oc-daemon-test-ocserv
+  oc-daemon:
+    build:
+      context: ../../../
+      dockerfile: test/ocserv/podman/Dockerfile
+      target: oc-daemon
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+    devices:
+      - "/dev/net/tun:/dev/net/tun"
+    networks:
+      - ext
+    container_name: oc-daemon-test-oc-daemon
+    environment:
+      - GOCOVERDIR=/gocover
+  web-ext:
+    build:
+      context: ../../../
+      dockerfile: test/ocserv/podman/Dockerfile
+      target: web-ext
+    networks:
+      - ext
+    container_name: oc-daemon-test-web-ext
+  web-int:
+    build:
+      context: ../../../
+      dockerfile: test/ocserv/podman/Dockerfile
+      target: web-int
+    cap_add:
+      - NET_ADMIN
+    networks:
+      - int
+    container_name: oc-daemon-test-web-int
+
+networks:
+  ext:
+    internal: true
+    name: oc-daemon-test-ext
+  int:
+    internal: true
+    name: oc-daemon-test-int

--- a/test/ocserv/tests.sh
+++ b/test/ocserv/tests.sh
@@ -1,0 +1,963 @@
+#!/bin/bash
+
+# executables
+PODMAN="podman"
+PODMAN_COMPOSE="podman-compose"
+GREP="grep"
+DATE="date --rfc-3339=seconds"
+TIMESTAMP="date +%s"
+
+# networks
+NETWORK_EXT_NAME="oc-daemon-test-ext"
+NETWORK_INT_NAME="oc-daemon-test-int"
+
+# containers
+OCSERV_NAME="oc-daemon-test-ocserv"
+OC_DAEMON_NAME="oc-daemon-test-oc-daemon"
+WEB_EXT_NAME="oc-daemon-test-web-ext"
+WEB_INT_NAME="oc-daemon-test-web-int"
+
+# log file
+LOG_FILE="test/ocserv/tests.log"
+
+###############################################################################
+###                                 Helpers                                 ###
+###############################################################################
+
+# number of tests, OKs and fails
+TESTS=0
+OKS=0
+FAILS=0
+
+# print test output
+out() {
+	echo "=== $($DATE): $1"
+}
+
+# start networks and containers
+start_containers() {
+	out "Starting networks and containers..."
+	COMPOSE_PARALLEL_LIMIT=1 $PODMAN_COMPOSE \
+		--file "$PWD/test/ocserv/podman/compose.yml" \
+		up \
+		--build \
+		--detach
+}
+
+# start networks and containers, ipv6 version
+start_containers_ipv6() {
+	out "Starting networks and containers..."
+	COMPOSE_PARALLEL_LIMIT=1 $PODMAN_COMPOSE \
+		--file "$PWD/test/ocserv/podman/compose-ipv6.yml" \
+		up \
+		--build \
+		--detach
+}
+
+# shut down networks and containers
+stop_containers() {
+	out "Stopping networks and containers..."
+	$PODMAN_COMPOSE --file "$PWD/test/ocserv/podman/compose.yml" down
+}
+
+# shut down networks and containers, ipv6_version
+stop_containers_ipv6() {
+	out "Stopping networks and containers..."
+	$PODMAN_COMPOSE --file "$PWD/test/ocserv/podman/compose-ipv6.yml" down
+}
+
+# get container settings
+get_settings() {
+	# ocserv
+	OCSERV_PID=$($PODMAN inspect --format "{{.State.Pid}}" $OCSERV_NAME)
+	OCSERV_IP_EXT=$($PODMAN inspect \
+		--format "{{range \$k,\$v := .NetworkSettings.Networks}}{{if eq \$k \"$NETWORK_EXT_NAME\"}}{{\$v.IPAddress}}{{end}}{{end}}" \
+		$OCSERV_NAME)
+	OCSERV_IP_INT=$($PODMAN inspect \
+		--format "{{range \$k,\$v := .NetworkSettings.Networks}}{{if eq \$k \"$NETWORK_INT_NAME\"}}{{\$v.IPAddress}}{{end}}{{end}}" \
+		$OCSERV_NAME)
+
+	# oc-daemon
+	OC_DAEMON_PID=$($PODMAN inspect --format "{{.State.Pid}}" $OC_DAEMON_NAME)
+	OC_DAEMON_IP_EXT=$($PODMAN inspect \
+		--format "{{range \$k,\$v := .NetworkSettings.Networks}}{{if eq \$k \"$NETWORK_EXT_NAME\"}}{{\$v.IPAddress}}{{end}}{{end}}" \
+		$OC_DAEMON_NAME)
+
+	# web-ext
+	WEB_EXT_PID=$($PODMAN inspect --format "{{.State.Pid}}" $WEB_EXT_NAME)
+	WEB_EXT_IP_EXT=$($PODMAN inspect \
+		--format "{{range \$k,\$v := .NetworkSettings.Networks}}{{if eq \$k \"$NETWORK_EXT_NAME\"}}{{\$v.IPAddress}}{{end}}{{end}}" \
+		$WEB_EXT_NAME)
+
+	# web-int
+	WEB_INT_PID=$($PODMAN inspect --format "{{.State.Pid}}" $WEB_INT_NAME)
+	WEB_INT_IP_INT=$($PODMAN inspect \
+		--format "{{range \$k,\$v := .NetworkSettings.Networks}}{{if eq \$k \"$NETWORK_INT_NAME\"}}{{\$v.IPAddress}}{{end}}{{end}}" \
+		$WEB_INT_NAME)
+
+	# print infos about containers
+	out "Networks:"
+	out "- $NETWORK_EXT_NAME"
+	out "- $NETWORK_INT_NAME"
+	out "Containers:"
+	out "- $OCSERV_NAME:"
+	out "    PID: $OCSERV_PID"
+	out "    IP_EXT: $OCSERV_IP_EXT"
+	out "    IP_INT: $OCSERV_IP_INT"
+	out "- $OC_DAEMON_NAME:"
+	out "    PID: $OC_DAEMON_PID"
+	out "    IP_EXT: $OC_DAEMON_IP_EXT"
+	out "- $WEB_EXT_NAME:"
+	out "    PID: $WEB_EXT_PID"
+	out "    IP_EXT: $WEB_EXT_IP_EXT"
+	out "- $WEB_INT_NAME:"
+	out "    PID: $WEB_INT_PID"
+	out "    IP_INT: $WEB_INT_IP_INT"
+}
+
+# configure routing
+configure_routing() {
+	out "Configuring routing in containers..."
+	$PODMAN exec "$WEB_INT_NAME" ip route add default via "$OCSERV_IP_INT"
+	$PODMAN exec "$WEB_INT_NAME" ip route show
+}
+
+# connect vpn, default settings
+connect_vpn_default() {
+	out "Connecting to VPN..."
+	$PODMAN exec "$OC_DAEMON_NAME" oc-client \
+		connect
+}
+
+# connect vpn, with settings from command line
+connect_vpn_cmdline() {
+	out "Connecting to VPN..."
+	$PODMAN exec "$OC_DAEMON_NAME" oc-client \
+		-ca ca-cert.pem \
+		-key client-key.pem \
+		-cert client-cert.pem \
+		-server "$OCSERV_NAME" \
+		connect
+}
+
+# disconnect vpn, default settings
+disconnect_vpn_default() {
+	out "Disconnecting from VPN..."
+	$PODMAN exec "$OC_DAEMON_NAME" oc-client \
+		disconnect
+}
+
+# disconnect vpn, settings from command line
+disconnect_vpn_cmdline() {
+	out "Disconnecting from VPN..."
+	$PODMAN exec "$OC_DAEMON_NAME" oc-client \
+		-ca ca-cert.pem \
+		-key client-key.pem \
+		-cert client-cert.pem \
+		-server "$OCSERV_NAME" \
+		disconnect
+}
+
+# reconnect vpn, default settings
+reconnect_vpn_default() {
+	out "Reconnecting to VPN..."
+	$PODMAN exec "$OC_DAEMON_NAME" oc-client \
+		reconnect
+}
+
+# reconnect vpn, settings from command line
+reconnect_vpn_cmdline() {
+	out "Reconnecting to VPN..."
+	$PODMAN exec "$OC_DAEMON_NAME" oc-client \
+		-ca ca-cert.pem \
+		-key client-key.pem \
+		-cert client-cert.pem \
+		-server "$OCSERV_NAME" \
+		reconnect
+}
+
+# save oc-client user settings
+save_oc_client_user_settings() {
+	out "Saving oc-client user settings..."
+	$PODMAN exec "$OC_DAEMON_NAME" oc-client \
+		-ca ca-cert.pem \
+		-key client-key.pem \
+		-cert client-cert.pem \
+		-server "$OCSERV_NAME" \
+		save
+
+	# check
+	$PODMAN exec "$OC_DAEMON_NAME" sh -c "cat ~/.config/oc-daemon/oc-client.json"
+}
+
+# save oc-client system settings
+save_oc_client_system_settings() {
+	out "Saving oc-client system settings..."
+	local config="{
+	\"ClientCertificate\": \"/client-cert.pem\",
+	\"ClientKey\": \"/client-key.pem\",
+	\"CACertificate\": \"/ca-cert.pem\",
+	\"VPNServer\": \"$OCSERV_NAME\"
+}"
+	$PODMAN exec "$OC_DAEMON_NAME" sh -c "echo '$config' > /var/lib/oc-daemon/oc-client.json"
+
+	# check
+	$PODMAN exec "$OC_DAEMON_NAME" cat /var/lib/oc-daemon/oc-client.json
+}
+
+# set xml profile
+set_profile() {
+	out "Setting XML profile..."
+	local web=$1
+
+	# read profile
+	local profile
+	profile=$(<"$PWD/test/ocserv/oc-daemon/profile.xml")
+
+	# read fingerprint
+	local sum
+	sum=$($PODMAN exec "$web" cat "/web-cert.sum")
+
+	# set finterprint in profile
+	profile=${profile/CERT_HASH/"$sum"}
+
+	# set https server in profile
+	profile=${profile/WEB_SERVER/"$web"}
+
+	# set profile
+	$PODMAN exec "$OC_DAEMON_NAME" sh -c "echo '$profile' > /var/lib/oc-daemon/profile.xml"
+
+	# check
+	$PODMAN exec "$OC_DAEMON_NAME" cat /var/lib/oc-daemon/profile.xml
+}
+
+# ping external web server
+ping_ext() {
+	out "Pinging external web server"
+	$PODMAN exec "$OC_DAEMON_NAME" ping -c 3 "$WEB_EXT_IP_EXT"
+}
+
+# ping internal web server
+ping_int() {
+	out "Pinging internal web server"
+	$PODMAN exec "$OC_DAEMON_NAME" ping -c 3 "$WEB_INT_IP_INT"
+}
+
+# curl external web server
+curl_ext() {
+	out "HTTP GET external web server"
+	$PODMAN exec "$OC_DAEMON_NAME" curl -v \
+		--silent \
+		--connect-timeout 3 \
+		"https://$WEB_EXT_NAME" \
+		--resolve "$WEB_EXT_NAME:443:$WEB_EXT_IP_EXT" \
+		--cacert /ca-cert.pem
+}
+
+# curl internal web server
+curl_int() {
+	out "HTTP GET internal web server"
+	$PODMAN exec "$OC_DAEMON_NAME" curl -v \
+		--silent \
+		--connect-timeout 3 \
+		"https://$WEB_INT_NAME" \
+		--resolve "$WEB_INT_NAME:443:$WEB_INT_IP_INT" \
+		--cacert /ca-cert.pem
+}
+
+# run command in first argument and check whether return code is an error
+expect_err() {
+	if $1; then
+		out "FAIL: Line ${LINENO}/${BASH_LINENO[*]}: $1 should return error"
+		((FAILS++))
+	else
+		out "OK: Line ${LINENO}/${BASH_LINENO[*]}: $1 returned error as expected"
+		((OKS++))
+	fi
+}
+
+# run command in first argument and check whether return code is OK/no error
+expect_ok() {
+	if ! $1; then
+		out "FAIL: Line ${LINENO}/${BASH_LINENO[*]}: $1 should not return error"
+		((FAILS++))
+	else
+		out "OK: Line ${LINENO}/${BASH_LINENO[*]}: $1 returned no error as expected"
+		((OKS++))
+	fi
+}
+
+# set ocserv config
+set_ocserv_config() {
+	out "Setting new ocserv config..."
+	local config=$1
+
+	# write it to ocserv
+	$PODMAN exec "$OCSERV_NAME" sh -c "echo '$config' > /etc/ocserv/ocserv.conf"
+
+	# reload ocserv
+	$PODMAN exec "$OCSERV_NAME" occtl reload
+
+	# wait
+	sleep 1
+
+	# check
+	$PODMAN exec "$OCSERV_NAME" cat /etc/ocserv/ocserv.conf
+}
+
+# show oc-client status on oc-daemon
+show_oc_client_status() {
+	$PODMAN exec "$OC_DAEMON_NAME" oc-client \
+		-ca ca-cert.pem \
+		-key client-key.pem \
+		-cert client-cert.pem \
+		-server "$OCSERV_NAME" \
+		status \
+		-verbose
+}
+
+# show routes on oc-daemon
+show_routes() {
+	$PODMAN exec "$OC_DAEMON_NAME" ip -4 route show table all
+	$PODMAN exec "$OC_DAEMON_NAME" ip -6 route show table all
+}
+
+# show nftables ruleset on oc-daemon
+show_nft_ruleset() {
+	$PODMAN exec "$OC_DAEMON_NAME" nft list ruleset
+}
+
+# restart oc-daemon on oc-daemon
+restart_oc_daemon() {
+	$PODMAN exec "$OC_DAEMON_NAME" systemctl restart oc-daemon.service
+}
+
+# stop oc-daemon on oc-daemon
+stop_oc_daemon() {
+	$PODMAN exec "$OC_DAEMON_NAME" systemctl stop oc-daemon.service
+}
+
+# get oc-daemon log on oc-daemon
+get_oc_daemon_log() {
+	$PODMAN exec "$OC_DAEMON_NAME" journalctl -u oc-daemon.service
+}
+
+# get errors in oc-daemon log on oc-daemon.
+# returns error if an error is found in log.
+# ignores some pre-defined errors, see ignore_errors
+get_log_errors() {
+	local ignore_errors=(
+		'msg="Could not read XML profile" error="open /var/lib/oc-daemon/profile.xml: no such file or directory"'
+		'stderr="sysctl: permission denied on key \\"net.ipv4.conf.all.src_valid_mark\\"'
+	)
+
+	local log
+	log=$(get_oc_daemon_log)
+
+	local errors
+	errors=$($GREP "level=error" <<< "$log")
+
+	for i in "${ignore_errors[@]}"; do
+		errors=$($GREP -v "$i" <<< "$errors")
+	done
+
+	if [ -n "${errors}" ];then
+		out "$errors"
+		return 1
+	fi
+}
+
+# directories for GOCOVER files in container and on host
+GOCOVERDIR="/gocover"
+HOST_GOCOVERDIR="$PWD/test/ocserv/gocover/$($TIMESTAMP)"
+
+# save GOCOVER directory
+save_gocover_dir() {
+	local dir="${HOST_GOCOVERDIR}/${TESTS}"
+	mkdir -p "$dir"
+	$PODMAN cp "${OC_DAEMON_NAME}:${GOCOVERDIR}/." "$dir"
+}
+
+# show GOCOVER percentage
+show_gocover_percent() {
+	local covdirs=""
+	for i in $(seq 1 "$NUM_TESTS"); do
+		if [ "$i" -eq 1 ]; then
+			covdirs=$HOST_GOCOVERDIR/$i
+		else
+			covdirs=$covdirs,$HOST_GOCOVERDIR/$i
+		fi
+	done
+	out "go tool covdata percent -i $covdirs"
+	while read -r line
+	do
+		    out "$line"
+	done < <(go tool covdata percent -i "$covdirs")
+}
+
+# show test summary
+show_summary() {
+	out "==============================="
+	out "=== Cumulative Test Summary ==="
+	out "==============================="
+	out "Tests: $TESTS"
+	out "OKs: $OKS"
+	out "FAILs: $FAILS"
+	out "==============================="
+}
+
+###############################################################################
+###                               Test Cases                                ###
+###############################################################################
+
+# run tests and expect external server OK and internal ERR
+test_expect_ok_err() {
+	show_oc_client_status
+	show_routes
+	show_nft_ruleset
+	expect_ok ping_ext
+	expect_err ping_int
+	expect_ok curl_ext
+	expect_err curl_int
+	expect_ok get_log_errors
+}
+
+# run tests and expect external server ERR and internal OK
+test_expect_err_ok() {
+	show_oc_client_status
+	show_routes
+	show_nft_ruleset
+	expect_err ping_ext
+	expect_ok ping_int
+	expect_err curl_ext
+	expect_ok curl_int
+	expect_ok get_log_errors
+}
+
+# run tests and expect external server OK and internal OK
+test_expect_ok_ok() {
+	show_oc_client_status
+	show_routes
+	show_nft_ruleset
+	expect_ok ping_ext
+	expect_ok ping_int
+	expect_ok curl_ext
+	expect_ok curl_int
+	expect_ok get_log_errors
+}
+
+# common parts of tests with default settings in ocserv.conf.
+test_default_common() {
+	get_settings
+	configure_routing
+
+	out "Testing before VPN connection..."
+	test_expect_ok_err
+
+	# connect vpn
+	connect_vpn_cmdline
+
+	out "Testing after VPN connection..."
+	test_expect_err_ok
+
+	# reconnect vpn
+	reconnect_vpn_cmdline
+
+	out "Testing after reconnecting VPN..."
+	test_expect_err_ok
+
+	# disconnect vpn
+	disconnect_vpn_cmdline
+
+	out "Testing after disconnecting VPN..."
+	test_expect_ok_err
+}
+
+# run test with default settings in ocserv.conf.
+test_default() {
+	out "Setting up test..."
+	start_containers
+
+	test_default_common
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers
+}
+
+# run test with default settings in ocserv.conf, ipv6 version.
+test_default_ipv6() {
+	out "Setting up test..."
+	start_containers_ipv6
+
+	test_default_common
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers_ipv6
+}
+
+# common parts of tests with split routing for ext-web.
+test_splitrt_common() {
+	get_settings
+	configure_routing
+
+	local config="# splitrt config
+auth = \"certificate\"
+tcp-port = 443
+udp-port = 443
+run-as-user = ocserv
+run-as-group = ocserv
+socket-file = /run/ocserv-socket
+chroot-dir = /var/lib/ocserv
+server-cert = /etc/ocserv/server-cert.pem
+server-key = /etc/ocserv/server-key.pem
+ca-cert = /etc/ocserv/ca-cert.pem
+isolate-workers = true
+max-clients = 16
+max-same-clients = 2
+rate-limit-ms = 100
+server-stats-reset-time = 604800
+keepalive = 32400
+dpd = 90
+mobile-dpd = 1800
+switch-to-tcp-timeout = 25
+try-mtu-discovery = false
+cert-user-oid = 0.9.2342.19200300.100.1.1
+tls-priorities = \"NORMAL:%SERVER_PRECEDENCE:%COMPAT:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.3\"
+auth-timeout = 240
+min-reauth-time = 300
+max-ban-score = 80
+ban-reset-time = 1200
+cookie-timeout = 300
+deny-roaming = false
+rekey-time = 172800
+rekey-method = ssl
+use-occtl = true
+pid-file = /run/ocserv.pid
+log-level = 1
+device = vpns
+predictable-ips = true
+default-domain = example.com
+ipv4-network = 192.168.1.0
+ipv4-netmask = 255.255.255.0
+dns = 192.168.1.1
+ping-leases = false
+
+# configure routing
+route = default
+no-route = $WEB_EXT_IP_EXT/32
+
+cisco-client-compat = true
+dtls-legacy = true
+client-bypass-protocol = false
+"
+	set_ocserv_config "$config"
+
+	out "Testing before VPN connection..."
+	test_expect_ok_err
+
+	# connect vpn
+	connect_vpn_cmdline
+
+	out "Testing after VPN connection..."
+	test_expect_ok_ok
+
+	# reconnect vpn
+	reconnect_vpn_cmdline
+
+	out "Testing after reconnecting VPN..."
+	test_expect_ok_ok
+
+	# disconnect vpn
+	disconnect_vpn_cmdline
+
+	out "Testing after disconnecting VPN..."
+	test_expect_ok_err
+}
+
+# run test with split routing for ext-web.
+test_splitrt() {
+	out "Setting up test..."
+	start_containers
+
+	test_splitrt_common
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers
+}
+# run test with split routing for ext-web, ipv6 version
+test_splitrt_ipv6() {
+	out "Setting up test..."
+	start_containers_ipv6
+
+	test_splitrt_common
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers_ipv6
+}
+
+# run test with with restart
+test_restart() {
+	out "Setting up test..."
+	start_containers
+	get_settings
+	configure_routing
+
+	# check errors in log before doing anything
+	sleep 3
+	expect_ok get_log_errors
+
+	# check errors in log after restart without vpn connection
+	restart_oc_daemon
+	expect_ok get_log_errors
+
+	# check errors in log after connecting vpn
+	connect_vpn_cmdline
+	sleep 3
+	expect_ok get_log_errors
+
+	# check errors in log after restart during connected vpn
+	restart_oc_daemon
+	expect_ok get_log_errors
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers
+}
+
+# run test with reconnect
+test_reconnect() {
+	out "Setting up test..."
+	start_containers
+	get_settings
+	configure_routing
+
+	# check errors in log before doing anything
+	expect_ok get_log_errors
+
+	# check errors in log after reconnect without vpn connection
+	reconnect_vpn_cmdline
+	sleep 3
+	test_expect_err_ok
+
+	# check errors in log after reconnect with vpn connection
+	reconnect_vpn_cmdline
+	sleep 3
+	test_expect_err_ok
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers
+}
+
+# run test with disconnect
+test_disconnect() {
+	out "Setting up test..."
+	start_containers
+	get_settings
+	configure_routing
+
+	# check errors in log before doing anything
+	expect_ok get_log_errors
+
+	# check errors in log after disconnect without vpn connection
+	disconnect_vpn_cmdline
+	sleep 3
+	test_expect_ok_err
+
+	# check errors in log after disconnect with vpn connection
+	connect_vpn_cmdline
+	disconnect_vpn_cmdline
+	sleep 3
+	test_expect_ok_err
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers
+}
+
+# run test with oc-client config
+test_occlient_config() {
+	out "Setting up test..."
+	start_containers
+	get_settings
+	configure_routing
+
+	# test with system settings
+	out "Testing with system settings..."
+	save_oc_client_system_settings
+
+	# connect vpn
+	connect_vpn_default
+	out "Testing with system settings, after VPN connection..."
+	test_expect_err_ok
+
+	# reconnect vpn
+	reconnect_vpn_default
+	out "Testing with system settings, after reconnecting VPN..."
+	test_expect_err_ok
+
+	# disconnect vpn
+	disconnect_vpn_default
+	out "Testing with system settings, after disconnecting VPN..."
+	test_expect_ok_err
+
+	# test with user settings
+	out "Testing with user settings..."
+	save_oc_client_user_settings
+
+	# connect vpn
+	connect_vpn_default
+	out "Testing with user settings, after VPN connection..."
+	test_expect_err_ok
+
+	# reconnect vpn
+	reconnect_vpn_default
+	out "Testing with user settings, after reconnecting VPN..."
+	test_expect_err_ok
+
+	# disconnect vpn
+	disconnect_vpn_default
+	out "Testing with user settings, after disconnecting VPN..."
+	test_expect_ok_err
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers
+}
+
+# run test with xml profile, always on enabled
+test_profile_alwayson() {
+	out "Setting up test..."
+	start_containers
+	get_settings
+	configure_routing
+
+	# set xml profile
+	set_profile $WEB_INT_NAME
+	sleep 1
+	test_expect_ok_err
+
+	# connect vpn
+	connect_vpn_cmdline
+	out "Testing after VPN connection before restart..."
+	test_expect_err_ok
+
+	# restart, load xml profile on startup
+	restart_oc_daemon
+	sleep 1
+	test_expect_ok_err
+
+	# connect vpn
+	connect_vpn_cmdline
+	out "Testing after VPN connection after restart..."
+	test_expect_err_ok
+
+	# set xml profile again, should not change anything
+	set_profile $WEB_INT_NAME
+	sleep 1
+	test_expect_err_ok
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers
+}
+
+# run test with xml profile, tnd enabled
+test_profile_tnd() {
+	out "Setting up test..."
+	start_containers
+	get_settings
+	configure_routing
+
+	# set xml profile, when oc-daemon is already running
+	# set external web server in profile, pretend to be in trusted network
+	set_profile $WEB_EXT_NAME
+	sleep 1
+	test_expect_ok_err
+
+	# connect vpn
+	connect_vpn_cmdline
+	out "Testing after VPN connection attempt before restart..."
+	test_expect_ok_err
+
+	# restart, load xml profile on startup
+	restart_oc_daemon
+	sleep 1
+	test_expect_ok_err
+
+	# connect vpn
+	connect_vpn_cmdline
+	out "Testing after VPN connection attempt after restart..."
+	test_expect_ok_err
+
+	# set internal web server in profile, not in a trusted network
+	set_profile $WEB_INT_NAME
+	sleep 1
+	test_expect_ok_err
+
+	# connect vpn
+	connect_vpn_cmdline
+	out "Testing after VPN connection after switching to internal server..."
+	test_expect_err_ok
+
+	out "Shutting down test..."
+	stop_oc_daemon
+	save_gocover_dir
+	stop_containers
+}
+
+# define test cases/runs
+TEST_RUNS=(
+	test_default
+	test_default_ipv6
+	test_splitrt
+	test_splitrt_ipv6
+	test_restart
+	test_reconnect
+	test_disconnect
+	test_occlient_config
+	test_profile_alwayson
+	test_profile_tnd
+)
+
+###############################################################################
+###                                Startup                                  ###
+###############################################################################
+
+# helper to run a single test
+run_test() {
+	((TESTS++))
+	out "==============================="
+	out "Test $TESTS/$NUM_TESTS: $1"
+	out "==============================="
+	out "Starting test"
+	local start_time=$SECONDS
+	$1
+	show_summary
+	out "Test done, $(( SECONDS - start_time))s, total ${SECONDS}s"
+}
+
+# run all tests
+run_all_tests() {
+	NUM_TESTS=${#TEST_RUNS[@]}
+	for i in "${TEST_RUNS[@]}"; do
+		run_test "$i"
+	done
+	show_gocover_percent
+}
+
+# run specific test
+run_specific_test() {
+	NUM_TESTS=1
+	run_test "$1"
+	show_gocover_percent
+}
+
+# show usage
+show_usage() {
+	echo "Usage of $0:"
+	echo "  help"
+	echo "        show this help"
+	echo "  list"
+	echo "        list all available tests"
+	echo "  up <ipv4|ipv6>"
+	echo "        start test setup without running any tests,"
+	echo "        remember to stop before running any tests"
+	echo "  down <ipv4|ipv6>"
+	echo "        stop previously started test setup"
+	echo "  all"
+	echo "        run all tests"
+	echo "  <test>"
+	echo "        run specific test, one of:"
+	echo "       " "${TEST_RUNS[@]}"
+}
+
+# check command line arguments
+if [ "$#" -lt 1 ]; then
+	show_usage
+	exit 2
+fi
+
+# handle command "up"
+command_up() {
+	case "$1" in
+		ipv4)
+			start_containers
+			;;
+		ipv6)
+			start_containers_ipv6
+			;;
+		*)
+			show_usage
+			exit 2
+			;;
+	esac
+}
+
+# handle command "down"
+command_down() {
+	case "$1" in
+		ipv4)
+			stop_containers
+			;;
+		ipv6)
+			stop_containers_ipv6
+			;;
+		*)
+			show_usage
+			exit 2
+			;;
+	esac
+}
+
+# parse command
+case "$1" in
+	help)
+		# handle command "help"
+		show_usage
+		exit 0
+		;;
+	list)
+		# handle command "list"
+		echo "${TEST_RUNS[@]}"
+		exit 0
+		;;
+	up)
+		# handle command "up"
+		command_up "$2"
+		;;
+	down)
+		# handle command "down"
+		command_down "$2"
+		;;
+	all)
+		# handle command "all"
+		run_all_tests 2>&1 | tee $LOG_FILE | $GREP "^==="
+		;;
+	*)
+		# handle specific test
+		if [[ ! " ${TEST_RUNS[*]} " =~ [[:space:]]$1[[:space:]] ]]; then
+			    echo "unknown test"
+			    exit 1
+		fi
+		run_specific_test "$1" 2>&1 | tee $LOG_FILE | $GREP "^==="
+		;;
+esac
+
+# return error if a test failed
+if [ $FAILS -ne 0 ]; then
+	exit 1
+fi

--- a/test/ocserv/web/Caddyfile
+++ b/test/ocserv/web/Caddyfile
@@ -1,0 +1,7 @@
+:443 {
+	tls /web-cert.pem /web-key.pem
+	respond <<MSG
+	hello from web server
+
+	MSG
+}


### PR DESCRIPTION
Add tests for OC-Daemon that use ocserv as VPN server. The tests use podman-compose to run OC-Daemon, ocserv and two web servers as containers in two networks: an external network and an internal network. OC-Daemon runs as VPN client in the external network. Ocserv is connected to both networks and enables a connected VPN client to reach the internal network. Each network contains one web server that can be used for connectivity checks and trusted network detection. The tests check OC-Daemon with VPN connections in various settings.