### PR TITLE
Add networkcheck.kde.org to Allowed Hosts in Traffic Policing

### DIFF
--- a/configs/oc-daemon.json
+++ b/configs/oc-daemon.json
@@ -44,7 +44,7 @@
 		"FirewallMark": "42111"
 	},
 	"TrafficPolicing": {
-		"AllowedHosts": ["connectivity-check.ubuntu.com", "detectportal.firefox.com", "www.gstatic.com", "clients3.google.com", "nmcheck.gnome.org"],
+		"AllowedHosts": ["connectivity-check.ubuntu.com", "detectportal.firefox.com", "www.gstatic.com", "clients3.google.com", "nmcheck.gnome.org", "networkcheck.kde.org"],
 		"ResolveTimeout": 2000000000,
 		"ResolveTries": 3,
 		"ResolveTriesSleep": 1000000000,

--- a/docs/development/traffic-policing.md
+++ b/docs/development/traffic-policing.md
@@ -53,6 +53,7 @@ CPD hosts are added to the allowed IPv4/6 hosts:
 - `www.gstatic.com` (Chrome)
 - `clients3.google.com` (Chromium)
 - `nmcheck.gnome.org` (Gnome)
+- `networkcheck.kde.org` (KDE)
 
 ## ICMP
 

--- a/internal/daemoncfg/config.go
+++ b/internal/daemoncfg/config.go
@@ -450,6 +450,7 @@ var (
 		"www.gstatic.com",               // chrome
 		"clients3.google.com",           // chromium
 		"nmcheck.gnome.org",             // gnome
+		"networkcheck.kde.org",          // kde
 	}
 
 	// PortalPorts are the default ports that are allowed to register on a

--- a/internal/daemoncfg/config_test.go
+++ b/internal/daemoncfg/config_test.go
@@ -825,7 +825,7 @@ func TestConfigLoad(t *testing.T) {
 		"FirewallMark": "42111"
 	},
 	"TrafficPolicing": {
-		"AllowedHosts": ["connectivity-check.ubuntu.com", "detectportal.firefox.com", "www.gstatic.com", "clients3.google.com", "nmcheck.gnome.org"],
+		"AllowedHosts": ["connectivity-check.ubuntu.com", "detectportal.firefox.com", "www.gstatic.com", "clients3.google.com", "nmcheck.gnome.org", "networkcheck.kde.org"],
 		"PortalPorts": [80, 443],
 		"ResolveTimeout": 2000000000,
 		"ResolveTries": 3,


### PR DESCRIPTION
Add networkcheck.kde.org to Allowed Hosts in Traffic Policing so it can be used for the Captive Portal Detection in KDE.