### PR TITLE
Send copy of ResolvedName from Resolver to TrafPol

### DIFF
--- a/internal/trafpol/resolver.go
+++ b/internal/trafpol/resolver.go
@@ -19,6 +19,15 @@ type ResolvedName struct {
 	TTL  time.Duration
 }
 
+// copy returns a copy of the ResolvedName.
+func (r *ResolvedName) copy() *ResolvedName {
+	return &ResolvedName{
+		Name: r.Name,
+		IPs:  append(r.IPs[:0:0], r.IPs...),
+		TTL:  r.TTL,
+	}
+}
+
 // sleepResolveTry is used to sleep before resolve (re)tries, can be canceled.
 func (r *ResolvedName) sleepResolveTry(ctx context.Context, config *daemoncfg.TrafficPolicing) {
 	timer := time.NewTimer(config.ResolveTriesSleep)
@@ -97,7 +106,7 @@ func (r *ResolvedName) resolve(ctx context.Context, config *daemoncfg.TrafficPol
 
 		// send update over updates channel
 		select {
-		case updates <- r:
+		case updates <- r.copy():
 		case <-ctx.Done():
 		}
 		return

--- a/internal/trafpol/resolver_test.go
+++ b/internal/trafpol/resolver_test.go
@@ -2,11 +2,43 @@ package trafpol
 
 import (
 	"net/netip"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/telekom-mms/oc-daemon/internal/daemoncfg"
 )
+
+// TestResolvedNameCopy tests copy of ResolvedName.
+func TestResolvedNameCopy(t *testing.T) {
+	// test empty, filled
+	for _, r := range []*ResolvedName{
+		{},
+		{
+			Name: "test",
+			IPs:  []netip.Addr{netip.MustParseAddr("192.168.1.1")},
+			TTL:  10 * time.Second,
+		},
+	} {
+		want := r
+		got := want.copy()
+
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	}
+
+	// test modification after copy
+	r1 := &ResolvedName{}
+	r2 := r1.copy()
+	r1.Name = "test"
+	r1.IPs = []netip.Addr{netip.MustParseAddr("192.168.1.1")}
+	r1.TTL = 10 * time.Second
+
+	if reflect.DeepEqual(r1, r2) {
+		t.Error("copies should not be equal after modification")
+	}
+}
 
 // TestResolverStartStop tests Start and Stop of Resolver.
 func TestResolverStartStop(_ *testing.T) {


### PR DESCRIPTION
Copy ResolvedNames before sending them from the Resolver over the updates channel to TrafPol to avoid a data race where the IPs in a ResolvedName are updated by the Resolver while TrafPol is reading them.