### PR TITLE
Fix typos in doc comments

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -631,7 +631,7 @@ func (d *Daemon) handleTNDResult(trusted bool) error {
 }
 
 // handleRunnerDisconnect handles a disconnect event from the OC runner,
-// cleaning up everthing. This is also called when stopping the daemon.
+// cleaning up everything. This is also called when stopping the daemon.
 func (d *Daemon) handleRunnerDisconnect() {
 	// make sure running and connected are not set
 	d.setStatusOCRunning(false)

--- a/internal/trafpol/trafpol_test.go
+++ b/internal/trafpol/trafpol_test.go
@@ -167,7 +167,7 @@ func TestTrafPolStartStop(t *testing.T) {
 	tp.Stop()
 }
 
-// TestTrafPolAddRemoveAllowedAddr tests AddAllowedAddr and RemoveAllowedAddr of Trafpol.
+// TestTrafPolAddRemoveAllowedAddr tests AddAllowedAddr and RemoveAllowedAddr of TrafPol.
 func TestTrafPolAddRemoveAllowedAddr(t *testing.T) {
 	// set dummy low level function for devmon
 	oldRegisterLinkUpdates := devmon.RegisterLinkUpdates
@@ -226,7 +226,7 @@ func TestTrafPolAddRemoveAllowedAddr(t *testing.T) {
 	tp.Stop()
 }
 
-// TestTrafPolGetState tests GetState of Trafpol.
+// TestTrafPolGetState tests GetState of TrafPol.
 func TestTrafPolGetState(t *testing.T) {
 	// set dummy low level function for devmon
 	oldRegisterLinkUpdates := devmon.RegisterLinkUpdates

--- a/pkg/vpnstatus/status.go
+++ b/pkg/vpnstatus/status.go
@@ -118,7 +118,7 @@ const (
 	TrafPolStateDisabled
 )
 
-// String resturns TrafPolState as string.
+// String returns TrafPolState as string.
 func (t TrafPolState) String() string {
 	switch t {
 	case TrafPolStateUnknown:
@@ -166,7 +166,7 @@ const (
 	TNDStateActive
 )
 
-// String resturns TNDState as string.
+// String returns TNDState as string.
 func (t TNDState) String() string {
 	switch t {
 	case TNDStateUnknown:


### PR DESCRIPTION
Fix typos in doc comments in:
- internal/daemon
- internal/trafpol
- pkg/vpnstatus