### PR TITLE
Ignore Fprintf error in default tool

### DIFF
--- a/tools/default/main.go
+++ b/tools/default/main.go
@@ -59,7 +59,7 @@ func main() {
 		}
 
 		// print to stdout
-		fmt.Fprintf(os.Stdout, "%s\n", b)
+		_, _ = fmt.Fprintf(os.Stdout, "%s\n", b)
 
 	case CommandLists:
 		// sort function
@@ -78,11 +78,11 @@ func main() {
 		}
 
 		// print to stdout
-		fmt.Fprintf(os.Stdout, "%s\n", b)
+		_, _ = fmt.Fprintf(os.Stdout, "%s\n", b)
 
 	case CommandTemplates:
 		// print to stdout
-		fmt.Fprintf(os.Stdout, "%s\n", cmdtmpl.DefaultTemplate)
+		_, _ = fmt.Fprintf(os.Stdout, "%s\n", cmdtmpl.DefaultTemplate)
 
 	default:
 		// unknown, print error message to stderr


### PR DESCRIPTION
Ignore errors when writing output to Stdout with Fprintf in the default tool to fix an errcheck warning.