### PR TITLE
Always allow DNS traffic with Traffic Policing

### DIFF
--- a/internal/cmdtmpl/command.go
+++ b/internal/cmdtmpl/command.go
@@ -83,7 +83,6 @@ table inet oc-daemon-filter {
         # set for allowed ports
         set allowports {
                 type inet_service
-                elements = { 53 }
         }
 
         chain input {
@@ -172,9 +171,13 @@ table inet oc-daemon-filter {
                         ind-neighbor-advert,
                 } counter accept
 
-                # accept traffic to allowed ports, e.g., DNS
+                # accept traffic to allowed ports
                 udp dport @allowports counter accept
                 tcp dport @allowports counter accept
+
+                # accept DNS traffic
+                udp dport 53 counter accept
+                tcp dport 53 counter accept
 
                 # accept DHCPv4 traffic
                 udp dport 67 udp sport 68 counter accept


### PR DESCRIPTION
If a captive portal is detected, Traffic Policing sets the Allowed Ports in the nftables rules to a list of captive portal ports (80, 443). However, this removes the existing entry for the DNS port. So, set static entries for DNS traffic in the nftables rules for Traffic Policing and use the Allowed Ports only for captive portal ports.