### PR TITLE
Configure systemd-resolved in ocserv tests

### DIFF
--- a/test/ocserv/podman/compose-ipv6.yml
+++ b/test/ocserv/podman/compose-ipv6.yml
@@ -30,6 +30,7 @@ services:
       - "/dev/net/tun:/dev/net/tun"
     networks:
       - ext
+    dns: none
     container_name: oc-daemon-test-oc-daemon
     environment:
       - GOCOVERDIR=/gocover

--- a/test/ocserv/podman/compose.yml
+++ b/test/ocserv/podman/compose.yml
@@ -30,6 +30,7 @@ services:
       - "/dev/net/tun:/dev/net/tun"
     networks:
       - ext
+    dns: none
     container_name: oc-daemon-test-oc-daemon
     environment:
       - GOCOVERDIR=/gocover


### PR DESCRIPTION
Configure systemd-resolved in the oc-daemon container before running each of the ocserv tests.