### PR TITLE
Add usergroup to OC-Client

### DIFF
--- a/internal/client/cmd.go
+++ b/internal/client/cmd.go
@@ -74,6 +74,7 @@ func setConfig(args []string) error {
 	profile := flags.String("profile", "", "set XML profile `file`")
 	srv := flags.String("server", "", "set server `address`")
 	usr := flags.String("user", "", "set `username`")
+	group := flags.String("group", "", "set `usergroup`")
 	sys := flags.Bool("system-settings", false, "use system settings "+
 		"instead of user configuration")
 	ver := flags.Bool("version", false, "print version")
@@ -201,6 +202,11 @@ func setConfig(args []string) error {
 	// set username
 	if *usr != "" {
 		config.User = *usr
+	}
+
+	// set usergroup
+	if *group != "" {
+		config.UserGroup = *group
 	}
 
 	// reset to system settings

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -449,6 +449,7 @@ var authenticate = func(d *DBusClient) error {
 	caFile := fmt.Sprintf("--cafile=%s", config.CACertificate)
 	xmlConfig := fmt.Sprintf("--xmlconfig=%s", config.XMLProfile)
 	user := fmt.Sprintf("--user=%s", config.User)
+	group := fmt.Sprintf("--usergroup=%s", config.UserGroup)
 
 	parameters := []string{
 		protocol,
@@ -475,6 +476,9 @@ var authenticate = func(d *DBusClient) error {
 	}
 	if config.User != "" {
 		parameters = append(parameters, user)
+	}
+	if config.UserGroup != "" {
+		parameters = append(parameters, group)
 	}
 	if config.Password != "" {
 		// read password from stdin and switch to non-interactive mode

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -274,6 +274,7 @@ func TestDBusClientAuthenticate(t *testing.T) {
 	conf.UserKey = "/test/user-key"
 	conf.CACertificate = "/test/ca"
 	conf.User = "test-user"
+	conf.UserGroup = "test-group"
 	conf.Password = "test-passwd"
 	client := &DBusClient{config: conf}
 

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	XMLProfile        string
 	VPNServer         string
 	User              string
+	UserGroup         string
 	Password          string `json:"-"`
 
 	OpenConnect string

--- a/pkg/client/config_test.go
+++ b/pkg/client/config_test.go
@@ -138,6 +138,7 @@ func TestLoadConfig(t *testing.T) {
 		XMLProfile:        "/some/profile",
 		VPNServer:         "server.example.com",
 		User:              "user1",
+		UserGroup:         "group1",
 
 		OpenConnect: "openconnect",
 		Protocol:    "test",


### PR DESCRIPTION
Add the command line argument "-group" to OC-Client that sets the usergroup during authentication.