### PR TITLE
Add client configuration file to the default tool

### DIFF
--- a/tools/default/main.go
+++ b/tools/default/main.go
@@ -5,6 +5,7 @@ Currently, it can print
 - Daemon Configuration File
 - Command Lists
 - Command Templates
+- Client Configuration File
 */
 package main
 
@@ -18,6 +19,7 @@ import (
 
 	"github.com/telekom-mms/oc-daemon/internal/cmdtmpl"
 	"github.com/telekom-mms/oc-daemon/internal/daemoncfg"
+	"github.com/telekom-mms/oc-daemon/pkg/client"
 )
 
 // command line arguments.
@@ -25,6 +27,7 @@ const (
 	DaemonConfig     = "daemon-config"
 	CommandLists     = "command-lists"
 	CommandTemplates = "command-templates"
+	ClientConfig     = "client-config"
 )
 
 // printUsage prints usage.
@@ -32,8 +35,9 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "Usage:\n"+
 		"\tdefault %s\n"+
 		"\tdefault %s\n"+
+		"\tdefault %s\n"+
 		"\tdefault %s\n",
-		DaemonConfig, CommandLists, CommandTemplates,
+		DaemonConfig, CommandLists, CommandTemplates, ClientConfig,
 	)
 }
 
@@ -83,6 +87,20 @@ func main() {
 	case CommandTemplates:
 		// print to stdout
 		_, _ = fmt.Fprintf(os.Stdout, "%s\n", cmdtmpl.DefaultTemplate)
+
+	case ClientConfig:
+		// get default config
+		c := client.NewConfig()
+
+		// convert to json
+		b, err := json.MarshalIndent(c, "", "    ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			return
+		}
+
+		// print to stdout
+		_, _ = fmt.Fprintf(os.Stdout, "%s\n", b)
 
 	default:
 		// unknown, print error message to stderr


### PR DESCRIPTION
Add printing the default values of the OC-Client configuration file to the default tool.