### PR TITLE
Update golangci-lint and GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Setup Go
         uses: actions/setup-go@v4
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,9 @@ jobs:
           go-version: stable
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
-          # https://github.com/golangci/golangci-lint-action/issues/135
-          skip-pkg-cache: true
   testAndBuild:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           with_archive: true
 
       - name: Test Build
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         version: [jammy] # add others, if same package should be available in many versions
     steps:
       - name: Deploy
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.PULL_TOKEN }}
           script: |+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
           with_archive: true
 
       - name: Release
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,25 @@
-# For documentation, see https://golangci-lint.run/usage/configuration/
-run:
-  timeout: 60m
+version: "2"
 linters:
   enable:
     - unconvert
     - unparam
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
     - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -72,7 +72,7 @@ func TestServerHandleRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if msg.Header.Type != TypeError || string(msg.Value) != ServerShuttingDown {
+	if msg.Type != TypeError || string(msg.Value) != ServerShuttingDown {
 		t.Error("unexpected reply")
 	}
 }

--- a/internal/client/cmd.go
+++ b/internal/client/cmd.go
@@ -34,10 +34,10 @@ func saveConfig() error {
 	userConfig := clientUserConfig()
 	userDir := filepath.Dir(userConfig)
 	if err := os.MkdirAll(userDir, 0700); err != nil {
-		return fmt.Errorf("Client could not create user dir: %w", err)
+		return fmt.Errorf("could not create user dir: %w", err)
 	}
 	if err := config.Save(userConfig); err != nil {
-		return fmt.Errorf("Client could not save config to file: %w", err)
+		return fmt.Errorf("could not save config to file: %w", err)
 	}
 	return nil
 }
@@ -150,7 +150,7 @@ func setConfig(args []string) error {
 		// load config from command line
 		c, err := client.LoadConfig(*cfgFile)
 		if err != nil {
-			return fmt.Errorf("Client could not load config %s: %w", *cfgFile, err)
+			return fmt.Errorf("could not load config %s: %w", *cfgFile, err)
 		}
 		c.Expand()
 		config = c
@@ -214,7 +214,7 @@ func setConfig(args []string) error {
 		systemConfig := clientSystemConfig()
 		c, err := client.LoadConfig(systemConfig)
 		if err != nil {
-			return fmt.Errorf("Client could not load system settings from system config %s: %w", systemConfig, err)
+			return fmt.Errorf("could not load system settings from system config %s: %w", systemConfig, err)
 		}
 		config = c
 	}


### PR DESCRIPTION
- Update GitHub actions
  - actions/checkout to v5
  - actions/setup-go to v6
  - actions/github-script to v8
  - goreleaser/goreleaser-action to v6
  - golangci/golangci-lint-action to v8
- Update golangci-lint configuration to version 2 with
  "golangci-lint migrate" because action only supports v2
- Remove option "skip-pkg-cache" that was removed in golangci-lint-action v5
- Fix golangci-lint errors