### PR TITLE
Use random port for DNS server in DNS Proxy tests

### DIFF
--- a/internal/dnsproxy/proxy_test.go
+++ b/internal/dnsproxy/proxy_test.go
@@ -23,16 +23,16 @@ func getTestConfig() *daemoncfg.DNSProxy {
 
 // getTestDNSServer returns a dns server for testing.
 func getTestDNSServer(t *testing.T, handler dns.Handler) *dns.Server {
-	s := &dns.Server{
-		Addr: "127.0.0.1:4255",
-		Net:  "udp",
-	}
-	p, err := net.ListenPacket("udp", s.Addr)
+	p, err := net.ListenPacket("udp", "127.0.0.1:")
 	if err != nil {
 		t.Fatal(err)
 	}
-	s.PacketConn = p
-	s.Handler = handler
+	s := &dns.Server{
+		Addr:       p.LocalAddr().String(),
+		Net:        "udp",
+		PacketConn: p,
+		Handler:    handler,
+	}
 	go func() {
 		if err := s.ActivateAndServe(); err != nil {
 			panic(err)


### PR DESCRIPTION
When creating a DNS server for testing in DNS Proxy tests, use a random port number to avoid port already in use errors.